### PR TITLE
fix: allow --help/--version without provider credentials

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,43 @@
 #!/usr/bin/env node
 
+const args = process.argv.slice(2);
+
+// Handle --help and --version before loading server (avoids credential validation)
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`Lynkr - Self-hosted Claude Code & Cursor proxy
+
+Usage: lynkr [options]
+
+Options:
+  --help, -h     Show this help message
+  --version, -v  Show version number
+
+Supported Providers:
+  databricks, azure-anthropic, ollama, openrouter, azure-openai,
+  openai, llamacpp, lmstudio, bedrock
+
+Environment Variables (vary by provider):
+  MODEL_PROVIDER              Provider to use (default: databricks)
+  DATABRICKS_API_BASE         Databricks workspace URL
+  DATABRICKS_API_KEY          Databricks API token
+  AZURE_ANTHROPIC_ENDPOINT    Azure Anthropic endpoint
+  AZURE_ANTHROPIC_API_KEY     Azure Anthropic API key
+  OLLAMA_ENDPOINT             Ollama server URL (default: http://localhost:11434)
+  OPENAI_API_KEY              OpenAI API key
+  PORT                        Server port (default: 8080)
+  LOG_LEVEL                   Logging level (default: info)
+  LOG_PRETTY                  Enable pretty-printed logs (requires pino-pretty)
+
+For full documentation, see: https://github.com/vishalveerareddy123/Lynkr
+`);
+  process.exit(0);
+}
+
+if (args.includes("--version") || args.includes("-v")) {
+  const pkg = require("../package.json");
+  console.log(pkg.version);
+  process.exit(0);
+}
+
+// Now load and start the server (triggers credential validation)
 require("../index.js");

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -1,6 +1,42 @@
 const pino = require("pino");
-const config = require("../config");
 
+// Lazy-load config to avoid validation during --help/--version
+let _config = null;
+function getConfig() {
+  if (!_config) {
+    _config = require("../config");
+  }
+  return _config;
+}
+
+// Only use pino-pretty if explicitly requested via LOG_PRETTY env var.
+// This avoids failures in production when pino-pretty isn't installed
+// (it's a devDependency).
+function createTransport() {
+  const usePretty = process.env.LOG_PRETTY === "true" || process.env.LOG_PRETTY === "1";
+  if (!usePretty) {
+    return undefined;
+  }
+
+  try {
+    // Check if pino-pretty is available before configuring transport
+    require.resolve("pino-pretty");
+    return {
+      target: "pino-pretty",
+      options: {
+        translateTime: "SYS:standard",
+        ignore: "pid,hostname",
+        colorize: true,
+      },
+    };
+  } catch {
+    // pino-pretty not installed; fall back to JSON output
+    console.error("[logger] LOG_PRETTY enabled but pino-pretty not installed, using JSON output");
+    return undefined;
+  }
+}
+
+const config = getConfig();
 const logger = pino({
   level: config.logger.level,
   name: "claude-backend",
@@ -11,17 +47,7 @@ const logger = pino({
     paths: ["req.headers.authorization", "req.headers.cookie"],
     censor: "***redacted***",
   },
-  transport:
-    config.env === "development"
-      ? {
-          target: "pino-pretty",
-          options: {
-            translateTime: "SYS:standard",
-            ignore: "pid,hostname",
-            colorize: true,
-          },
-        }
-      : undefined,
+  transport: createTransport(),
 });
 
 module.exports = logger;

--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,9 @@ function createApp() {
 }
 
 function start() {
+  // Validate configuration before starting (checks for required credentials)
+  config.validateConfig();
+
   const app = createApp();
   const server = app.listen(config.port, () => {
     console.log(`Claude→Databricks proxy listening on http://localhost:${config.port}`);


### PR DESCRIPTION
- Parse CLI args before loading server to handle --help/-h and --version/-v early, avoiding credential validation
- Make pino-pretty opt-in via LOG_PRETTY env var instead of auto-enabling in development mode (fixes "unable to determine transport target" error when devDependency not installed)
- Move config validation from module top-level to validateConfig() function called only when starting the server

Fixes Homebrew install failing on `lynkr --version` due to:
1. pino-pretty not bundled in production
2. Missing credentials throwing before args could be parsed

- https://github.com/Homebrew/homebrew-core/pull/263311

cc @vishalveerareddy123