### PR TITLE
Generalized and corrected Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 RUN apk add --no-cache python3 py3-pip make g++ git
 
 # Install searxng (local search provider)
-RUN pip install --no-cache-dir searxng
+#RUN pip install --no-cache-dir searxng
 
 # Copy dependency manifests first for better layer caching
 COPY package.json package-lock.json ./
@@ -55,7 +55,8 @@ ENV MODEL_PROVIDER="databricks" \
     PORT="8081" \
     LOG_LEVEL="info" \
     WORKSPACE_ROOT="/workspace" \
-    WEB_SEARCH_ENDPOINT="http://localhost:8888/search"
+    WEB_SEARCH_ENDPOINT="http://searxng:8888/search" \
+    NODE_ENV="production"
 
 # Databricks Configuration (default provider)
 ENV DATABRICKS_API_BASE="https://example.cloud.databricks.com" \
@@ -144,4 +145,6 @@ ENV MEMORY_ENABLED="true" \
 USER nodejs
 
 # Run the proxy
-CMD ["./start.sh"]
+#CMD ["./start.sh"]
+CMD ["node","index.js"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # Lynkr proxy service
   lynkr:
@@ -7,8 +5,9 @@ services:
     container_name: lynkr
     image: lynkr:2.0.0
     ports:
-      - "8081:8081"
-      - "8888:8888"
+      - "8081:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       # ============================================================
       # PRIMARY MODEL PROVIDER
@@ -42,12 +41,14 @@ services:
       # - qwen2.5:14b (strong reasoning, 7b struggles with tools)
       # - mistral:7b-instruct (fast and capable)
       PREFER_OLLAMA: ${PREFER_OLLAMA:-true}
-      OLLAMA_ENDPOINT: http://ollama:11434
+#      OLLAMA_ENDPOINT: http://ollama:11434
+      OLLAMA_ENDPOINT: http://host.docker.internal:11434
       OLLAMA_MODEL: ${OLLAMA_MODEL:-llama3.1:8b}
       OLLAMA_MAX_TOOLS_FOR_ROUTING: ${OLLAMA_MAX_TOOLS_FOR_ROUTING:-3}
       # Ollama Embeddings (for Cursor @Codebase search)
       OLLAMA_EMBEDDINGS_MODEL: ${OLLAMA_EMBEDDINGS_MODEL:-nomic-embed-text}
-      OLLAMA_EMBEDDINGS_ENDPOINT: ${OLLAMA_EMBEDDINGS_ENDPOINT:-http://ollama:11434/api/embeddings}
+#      OLLAMA_EMBEDDINGS_ENDPOINT: ${OLLAMA_EMBEDDINGS_ENDPOINT:-http://ollama:11434/api/embeddings}
+      OLLAMA_EMBEDDINGS_ENDPOINT: ${OLLAMA_EMBEDDINGS_ENDPOINT:-http://host.docker.internal:11434/api/embeddings}
 
       # ============================================================
       # OPENROUTER CONFIGURATION
@@ -131,7 +132,7 @@ services:
       # ============================================================
       PORT: ${PORT:-8081}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      WEB_SEARCH_ENDPOINT: ${WEB_SEARCH_ENDPOINT:-http://localhost:8888/search}
+      WEB_SEARCH_ENDPOINT: ${WEB_SEARCH_ENDPOINT:-http://searxng:8888/search}
       WORKSPACE_ROOT: /workspace
 
       # ============================================================
@@ -144,9 +145,6 @@ services:
     volumes:
       - ./data:/app/data  # Persist SQLite databases
       - .:/workspace      # Mount workspace
-    depends_on:
-      ollama:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - lynkr-network
@@ -173,6 +171,8 @@ services:
   ollama:
     image: ollama/ollama:latest
     container_name: ollama
+    profiles:
+      - ollama
     ports:
       - "11434:11434"
     volumes:
@@ -220,11 +220,37 @@ services:
   #     timeout: 10s
   #     retries: 3
 
+  # Local searxng search service (web search provider)
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    ports:
+      - "8888:8080"
+    volumes:
+      - searxng-data:/etc/searxng
+#    environment:
+      # you can add SEARX settings here if needed (e.g. timezone, settings.yml mount, etc.)
+      # see https://docs.searxng.org/admin/installation-docker.html#environment-variables
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
+    restart: unless-stopped
+    networks:
+      - lynkr-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8888/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
 volumes:
   ollama-data:
     driver: local
   # ollama-webui-data:
   #   driver: local
+  searxng-data:
+    driver: local
 
 networks:
   lynkr-network:


### PR DESCRIPTION
Corrected a series of failures that prevented docker deployment discovered related to https://github.com/Fast-Editor/Lynkr/issues/12 :

- Separated out SearXNG to it's own container - removed erroneous python based setup from base Lynkr container, updated related environment variables to reflect properly networked deployment using the searxng docker image.
- Corrected NODE_ENV to aoid pino-pretty dev depencency failure - pino-pretty is a development dependency not included in the production docker container so we need to define NODE_ENV=production to avoid use of the dev-depenency. Alternately we could make pino-pretty a production dependency but the docker dependency should probably default to production anyway.
- Corrected Lynkr startup to call node index.js directly rather than initializing a shell and exec process to which node is a child. This streamlines startup and hutdown process management, reducing the liklihood of hung containers not shutting down properly.
- Added a docker Profile 'ollama' to govern whether a local ollama server is started with `docker compose up -d`. With this change, in order to start ollama as part of the docker compose stack, use the command `docker compose --profile ollama up -d`

This resolves all the issues observed on a Macbook Pro with 128GB ram and a locally already-deployed model runner. Tested with both Ollama and LM Studio (OpenAI API endpoint).
