### PR TITLE
Fix duplicate module.exports in MCP registry

### DIFF
--- a/src/mcp/registry.js
+++ b/src/mcp/registry.js
@@ -213,13 +213,3 @@ module.exports = {
   getClient,
   listClients,
 };
-
-module.exports = {
-  registerServer,
-  listServers,
-  getServer,
-  clearServers,
-  loadFromManifest,
-  loadConfiguredServers,
-  hasLoadedManifest,
-};


### PR DESCRIPTION
## Summary

Fixes a bug where `src/mcp/registry.js` had two `module.exports` blocks, with the second one overwriting the first and causing three functions to be unavailable.

## Problem

The file had duplicate `module.exports`:
- **First** (lines 204-215): Exports 10 functions ✅
- **Second** (lines 217-225): Exports only 7 functions ❌ (overwrites first)

This caused these functions to be **undefined** when imported by other modules:
- `ensureClient`
- `getClient`
- `listClients`

## Impact

These functions are actively used in:
- `src/mcp/index.js` - imports all three
- `src/tools/mcp.js` - uses `ensureClient`
- `src/tools/mcp-remote.js` - uses `ensureClient`

The code likely worked due to the internal usage in `loadConfiguredServers()` (line 158), but external imports would fail.

## Root Cause

The duplicate existed since initial import (commit `40f5928`), likely a copy-paste error.

## Fix

Remove the second `module.exports` block (lines 217-225).

## Changes

**Files modified**: 1
- `src/mcp/registry.js` (-10 lines)

## Testing

- ✅ Verified only one `module.exports` remains
- ✅ All 10 functions properly exported
- ✅ No functional change (fixing existing bug)