### PR TITLE
Improve tool calling response handling

### DIFF
--- a/src/orchestrator/index.js
+++ b/src/orchestrator/index.js
@@ -2562,7 +2562,52 @@ IMPORTANT TOOL USAGE RULES:
         }
       }
 
-      continue;
+      logger.info({
+        sessionId: session?.id ?? null,
+        step: steps,
+        toolCallsExecuted: toolCallsExecuted,
+        totalToolCallsInThisStep: toolCalls.length,
+        messageCount: cleanPayload.messages.length,
+        lastMessageRole: cleanPayload.messages[cleanPayload.messages.length - 1]?.role,
+      }, "Tool execution complete");
+
+      // Return tool results directly to CLI - no more LLM call needed
+      // The tool result IS the answer (e.g., file contents for Read)
+      if (accumulatedToolResults.length > 0) {
+        auditLog("=== RETURNING TOOL RESULTS DIRECTLY TO CLI ===", {
+          sessionId: session?.id ?? null,
+          toolResultCount: accumulatedToolResults.length,
+          toolNames: accumulatedToolResults.map(r => r.tool_name)
+        });
+
+        // Convert tool_result blocks to text blocks for CLI display
+        // The CLI only understands text/tool_use in responses, not tool_result
+        const directResponse = {
+          id: `msg_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          content: accumulatedToolResults.map(r => ({
+            type: "text",
+            text: r.content
+          })),
+          model: requestedModel,
+          stop_reason: "end_turn",
+          usage: { input_tokens: 0, output_tokens: 0 }
+        };
+
+        return {
+          response: {
+            status: 200,
+            body: directResponse,
+            terminationReason: "tool_result_direct",
+          },
+          steps,
+          durationMs: Date.now() - start,
+          terminationReason: "tool_result_direct",
+        };
+      }
+
+      continue; // Only if no tool results (shouldn't happen)
     }
 
     let anthropicPayload;

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -88,6 +88,10 @@ const TOOL_ALIASES = {
   runtests: "workspace_test_run",
   testsummary: "workspace_test_summary",
   testhistory: "workspace_test_history",
+  // Glob has dedicated tool in src/tools/indexer.js (registerGlobTool)
+  // - returns plain text format instead of JSON
+  // glob: "workspace_list",
+  // Glob: "workspace_list",
 };
 
 function coerceString(value) {


### PR DESCRIPTION
## Summary

- Add fallback parsing for Ollama models that return tool calls as JSON text in message content instead of using the structured `tool_calls` field
- Return tool results directly to CLI instead of making a follow-up LLM call, reducing latency and preventing hallucinated rewrites of output
- Add dedicated Glob tool returning plain text (one path per line) instead of JSON, with `workspace_list` accepting both `pattern` and `patterns`
- Clarify why Glob is not aliased to `workspace_list` (format mismatch)

## Files Changed

| File | Change |
|------|--------|
| `src/clients/ollama-utils.js` | +69 lines — fallback JSON parsing for tool calls in message content |
| `src/orchestrator/index.js` | +47/-1 lines — return tool results directly, skip follow-up LLM call |
| `src/tools/index.js` | +4 lines — register new Glob tool |
| `src/tools/indexer.js` | +50/-3 lines — Glob tool impl, dual-param workspace_list |

## Test plan

- [ ] Verify Ollama models that return tool calls as JSON text are correctly parsed
- [ ] Verify tool results are returned directly without a follow-up LLM call
- [ ] Verify Glob tool returns one file path per line (plain text)
- [ ] Verify `workspace_list` accepts both `pattern` and `patterns` parameters

Found some issues, removing for now