### PR TITLE
Add external file read with tilde expansion and user approval flow

### DIFF
--- a/src/clients/standard-tools.js
+++ b/src/clients/standard-tools.js
@@ -24,13 +24,17 @@ const STANDARD_TOOLS = [
   },
   {
     name: "Read",
-    description: "Reads a file from the local filesystem. You can access any file directly by using this tool.",
+    description: "Reads a file from the local filesystem. You can access any file directly by using this tool. For files outside the workspace, the user must approve access first.",
     input_schema: {
       type: "object",
       properties: {
         file_path: {
           type: "string",
-          description: "Relative path within workspace (e.g., 'config.js', 'src/index.ts'). DO NOT use absolute paths."
+          description: "Path to the file. Use relative paths for workspace files (e.g., 'src/index.ts'). For files outside the workspace use absolute paths or ~ for the home directory (e.g., '~/Documents/notes.md', '/etc/hosts'). Each call reads ONE file only — do not pass multiple paths."
+        },
+        user_approved: {
+          type: "boolean",
+          description: "Set to true ONLY after the user has explicitly approved reading a file outside the workspace. Never set this to true without asking the user first."
         },
         limit: {
           type: "number",


### PR DESCRIPTION
## Summary
- Enable fs_read to handle paths outside the workspace (~/... and absolute paths)
- Two-phase approval flow: tool returns 403 asking LLM to get user confirmation, then reads on second call with user_approved=true
- Write/edit operations remain workspace-only

## Problem
The fs_read tool could only read files inside the workspace directory. Users working with external configuration files, documentation, or system files had no way to read them through the tool interface.

## Changes
- **src/workspace/index.js**: Added `expandTilde()`, `isExternalPath()`, and `readExternalFile()` utility functions
- **src/tools/workspace.js**: Added external path detection with 403 approval gate before allowing external reads
- **src/clients/standard-tools.js**: Updated Read tool schema with `user_approved` parameter and expanded `file_path` description

## Testing
- Workspace-relative reads continue to work unchanged
- `~/Documents/file.txt` correctly resolves and reads after user approval
- Absolute paths like `/etc/hosts` work with approval flow
- Write and edit operations remain workspace-only (no external writes)
- `npm run test:unit` passes with no regressions