### PR TITLE
Handle Ollama offline gracefully with retry and 503 response

### DIFF
--- a/src/clients/retry.js
+++ b/src/clients/retry.js
@@ -10,7 +10,7 @@ const DEFAULT_CONFIG = {
   backoffMultiplier: 2,
   jitterFactor: 0.1, // 10% jitter
   retryableStatuses: [429, 500, 502, 503, 504],
-  retryableErrors: ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ENETUNREACH'],
+  retryableErrors: ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ENETUNREACH', 'ECONNREFUSED'],
 };
 
 /**
@@ -41,6 +41,11 @@ function isRetryable(error, response, config) {
 
   // Check error codes
   if (error && error.code && config.retryableErrors.includes(error.code)) {
+    return true;
+  }
+
+  // Check nested cause (Node undici wraps connection errors as TypeError)
+  if (error && error.cause?.code && config.retryableErrors.includes(error.cause.code)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Add ECONNREFUSED to retryable errors so connection-refused gets retried with backoff
- Wrap invokeModel in try/catch returning structured 503 instead of raw TypeError bubbling to Express

## Problem
When the Ollama provider was offline, the raw TypeError from the failed fetch crashed through to Express error middleware, producing an unhelpful 500 error. The retry client also didn't recognize ECONNREFUSED, so it failed immediately without retrying.

## Changes
- **src/clients/retry.js**: Added `ECONNREFUSED` to retryable errors list; added check for nested `.cause.code` since Node's undici wraps connection errors as TypeError
- **src/orchestrator/index.js**: Wrapped `invokeModel` call in try/catch that detects connection errors and returns a structured 503 with `provider_unreachable` error type

## Testing
- Stopped Ollama, sent request → returns clean 503 with `provider_unreachable`
- Previously: raw TypeError crash in Express middleware
- Started Ollama back up → requests resume normally
- ECONNREFUSED triggers backoff retries before returning 503
- `npm run test:unit` passes with no regressions