### PR TITLE
Strip system-reminder blocks before smart tool selection classification

### DIFF
--- a/src/tools/smart-selection.js
+++ b/src/tools/smart-selection.js
@@ -9,6 +9,9 @@
 
 const logger = require('../logger');
 
+// Strip system-reminder blocks injected by the CLI before classification
+const SYSTEM_REMINDER_PATTERN = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
+
 // Pre-compiled regex patterns for performance (avoid recompiling on every request)
 const GREETING_PATTERN = /^(hi|hello|hey|good morning|good afternoon|good evening|howdy|greetings|sup|yo)[\s\.\!\?]*$/i;
 const QUESTION_PATTERN = /^(what is|what's|how does|when|where|why|explain|define|tell me about|can you explain)/i;
@@ -190,7 +193,10 @@ function classifyRequestType(payload) {
     return { type: 'coding', confidence: 0.5, keywords: [] };
   }
 
-  const content = extractContent(lastMessage);
+  const rawContent = extractContent(lastMessage);
+  // Strip <system-reminder> blocks before classification to prevent
+  // CLI-injected keywords (search, explain, documentation) from polluting results
+  const content = rawContent.replace(SYSTEM_REMINDER_PATTERN, '').trim();
   const contentLower = content.toLowerCase();
   const messageCount = payload.messages?.length ?? 0;
 


### PR DESCRIPTION
## Summary
- Strip `<system-reminder>` blocks from user messages before running the smart tool selection classifier

## Problem
The CLI injects `<system-reminder>` blocks into user messages containing keywords like "search", "explain", and "documentation". The smart selection classifier scans the full message content including these injected blocks, causing misclassification based on keywords the user never typed. For example, a simple greeting could be classified as a "research" request because the system-reminder contained the word "search".

## Changes
- **src/tools/smart-selection.js**: Added pre-compiled `SYSTEM_REMINDER_PATTERN` regex; strip matched blocks from content before classification in `classifyRequestType()`

## Testing
- Messages with system-reminder blocks now classify based on actual user content
- Simple greetings no longer misclassified as research/coding requests
- Messages without system-reminder blocks behave identically
- `npm run test:unit` passes with no regressions