### PR TITLE
Add TOPIC_DETECTION_MODEL env var for topic detection model override

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -136,6 +136,10 @@ const zaiModel = process.env.ZAI_MODEL?.trim() || "GLM-4.7";
 const vertexApiKey = process.env.VERTEX_API_KEY?.trim() || process.env.GOOGLE_API_KEY?.trim() || null;
 const vertexModel = process.env.VERTEX_MODEL?.trim() || "gemini-2.0-flash";
 
+// Topic detection model override
+// Values: "default" (use main model) or a model name to redirect topic detection to a lighter model
+const topicDetectionModel = (process.env.TOPIC_DETECTION_MODEL ?? "default").trim();
+
 // Hot reload configuration
 const hotReloadEnabled = process.env.HOT_RELOAD_ENABLED !== "false"; // default true
 const hotReloadDebounceMs = Number.parseInt(process.env.HOT_RELOAD_DEBOUNCE_MS ?? "1000", 10);
@@ -596,6 +600,7 @@ var config = {
   modelProvider: {
     type: modelProvider,
     defaultModel,
+    topicDetectionModel,
     // Hybrid routing settings
     preferOllama,
     fallbackEnabled,
@@ -885,6 +890,7 @@ function reloadConfig() {
   config.modelProvider.preferOllama = process.env.PREFER_OLLAMA === "true";
   config.modelProvider.fallbackEnabled = process.env.FALLBACK_ENABLED !== "false";
   config.modelProvider.fallbackProvider = (process.env.FALLBACK_PROVIDER ?? "databricks").toLowerCase();
+  config.modelProvider.topicDetectionModel = (process.env.TOPIC_DETECTION_MODEL ?? "default").trim();
 
   // Log level
   config.logger.level = process.env.LOG_LEVEL ?? "info";


### PR DESCRIPTION
## Summary
- Add `TOPIC_DETECTION_MODEL` env var to redirect topic detection to a lighter model

## Problem
Topic detection requests use the same large model as the main request. For users running local models, this adds unnecessary GPU load for a simple classification task.

## Changes
- **src/config/index.js**: Added `TOPIC_DETECTION_MODEL` env var (default: `"default"`), wired into config object and `reloadConfig()` for hot reload support

## Configuration
```bash
# Use main model (default, unchanged behavior)
TOPIC_DETECTION_MODEL=default

# Redirect to a lighter model
TOPIC_DETECTION_MODEL=llama3.2:1b
```

## Testing
- Default/unset: behavior unchanged
- Set to model name: config correctly reads the value
- Hot reload picks up changes without restart
- `npm run test:unit` passes with no regressions