### PR TITLE
feat: add Eden AI provider (OpenAI-compatible, 600+ models, EU/GDPR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,16 @@ OPENROUTER_ENDPOINT=https://openrouter.ai/api/v1/chat/completions
 # DESCRIPTION: Cap on tool count sent during routing.
 OPENROUTER_MAX_TOOLS_FOR_ROUTING=15
 
+# Eden AI (600+ models via single API, OpenAI-compatible, EU/GDPR)
+# DESCRIPTION: Eden AI API key.
+# EDENAI_API_KEY=your-edenai-key
+# DESCRIPTION: Default Eden AI model (provider/model naming).
+EDENAI_MODEL=openai/gpt-4o-mini
+# DESCRIPTION: Embedding model used through Eden AI.
+EDENAI_EMBEDDINGS_MODEL=openai/text-embedding-ada-002
+# DESCRIPTION: Eden AI chat completions endpoint (OpenAI-compatible v3).
+EDENAI_ENDPOINT=https://api.edenai.run/v3/chat/completions
+
 # ------------------------------------------------------------------------------
 # Databricks
 # ------------------------------------------------------------------------------

--- a/.github/workflows/edenai-integration.yml
+++ b/.github/workflows/edenai-integration.yml
@@ -1,0 +1,75 @@
+name: Eden AI Provider Tests
+
+on:
+  push:
+    paths:
+      - 'src/config/index.js'
+      - 'src/clients/databricks.js'
+      - 'src/orchestrator/index.js'
+      - 'src/api/openai-router.js'
+      - 'src/api/providers-handler.js'
+      - 'src/routing/**'
+      - 'src/clients/provider-capabilities.js'
+      - 'test/edenai-integration.test.js'
+      - '.github/workflows/edenai-integration.yml'
+  pull_request:
+    paths:
+      - 'src/config/index.js'
+      - 'src/clients/databricks.js'
+      - 'src/orchestrator/index.js'
+      - 'src/api/openai-router.js'
+      - 'src/api/providers-handler.js'
+      - 'src/routing/**'
+      - 'src/clients/provider-capabilities.js'
+      - 'test/edenai-integration.test.js'
+
+# Non-secret, safe to expose to all steps.
+env:
+  PYTHONUNBUFFERED: "1"
+  EDENAI_MODEL: openai/gpt-4o-mini
+
+jobs:
+  edenai-tests:
+    name: Eden AI provider test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Mirror the repo's primary CI (ci.yml): pnpm + ignore-scripts is the
+      # proven, fast install recipe here (plain `npm ci` hits an npm
+      # "Exit handler never called" crash with this dependency tree).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install
+        run: pnpm install --no-optional --ignore-scripts --no-frozen-lockfile
+        timeout-minutes: 5
+
+      # Offline unit tests — no secret needed. Uses a dummy key.
+      - name: Unit tests (config, routing, capabilities)
+        env:
+          DATABRICKS_API_KEY: test-key
+          DATABRICKS_API_BASE: http://test.com
+        run: node --test test/edenai-integration.test.js
+
+      # Live end-to-end test against api.edenai.run.
+      # GOLDEN RULE: the secret is scoped to THIS step only — never at the
+      # workflow/job `env:` level — so a compromised third-party action in
+      # another step can't exfiltrate it. Skips automatically on fork PRs
+      # (no secret available) because the test self-skips when the key is unset.
+      - name: Live integration test (Eden AI v3)
+        env:
+          # Non-secret dummy creds so config loads (repo convention); the real
+          # secret below stays scoped to this step only.
+          DATABRICKS_API_KEY: test-key
+          DATABRICKS_API_BASE: http://test.com
+          EDENAI_LIVE: "1"
+          EDENAI_API_KEY: ${{ secrets.EDENAI_API_KEY }}
+        run: node --test test/edenai-integration.test.js

--- a/bin/lynkr-init.js
+++ b/bin/lynkr-init.js
@@ -98,6 +98,15 @@ const PROVIDERS = {
     extras: [],
     defaultModel: 'anthropic/claude-sonnet-4',
   },
+  edenai: {
+    label: 'Eden AI (600+ models, one key, EU/GDPR)',
+    local: false,
+    creds: [
+      { key: 'EDENAI_API_KEY', label: 'Eden AI API key', secret: true },
+    ],
+    extras: [],
+    defaultModel: 'anthropic/claude-sonnet-4-5',
+  },
   databricks: {
     label: 'Databricks Foundation Models',
     local: false,
@@ -154,7 +163,7 @@ const PROVIDERS = {
 
 const PROVIDER_ORDER = [
   'ollama', 'llamacpp', 'lmstudio',
-  'azure-anthropic', 'azure-openai', 'openai', 'openrouter',
+  'azure-anthropic', 'azure-openai', 'openai', 'openrouter', 'edenai',
   'databricks', 'bedrock', 'vertex', 'zai', 'moonshot',
 ];
 const TIERS = ['SIMPLE', 'MEDIUM', 'COMPLEX', 'REASONING'];
@@ -304,6 +313,10 @@ const BASELINE_ENV = {
   OPENROUTER_EMBEDDINGS_MODEL: 'openai/text-embedding-ada-002',
   OPENROUTER_ENDPOINT: 'https://openrouter.ai/api/v1/chat/completions',
   OPENROUTER_MAX_TOOLS_FOR_ROUTING: '15',
+  EDENAI_API_KEY: '',
+  EDENAI_MODEL: 'openai/gpt-4o-mini',
+  EDENAI_EMBEDDINGS_MODEL: 'openai/text-embedding-ada-002',
+  EDENAI_ENDPOINT: 'https://api.edenai.run/v3/chat/completions',
   MOONSHOT_API_KEY: '',
   MOONSHOT_ENDPOINT: 'https://api.moonshot.ai/v1/chat/completions',
   MOONSHOT_MODEL: 'kimi-k2.6',

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -13,6 +13,7 @@ Lynkr supports multiple AI model providers, giving you flexibility in choosing t
 | **AWS Bedrock** | Cloud | 100+ (Claude, DeepSeek, Qwen, Nova, Titan, Llama, Mistral) | $-$$$ | Cloud | Easy |
 | **Databricks** | Cloud | Claude Sonnet 4.5, Opus 4.5 | $$$ | Cloud | Medium |
 | **OpenRouter** | Cloud | 100+ (GPT, Claude, Gemini, Llama, Mistral, etc.) | $-$$ | Cloud | Easy |
+| **Eden AI** | Cloud | 600+ (GPT, Claude, Gemini, Mistral, etc.) | $-$$ | Cloud (EU/GDPR) | Easy |
 | **Ollama** | Local | Unlimited (free, offline) | **FREE** | 🔒 100% Local | Easy |
 | **llama.cpp** | Local | Any GGUF model | **FREE** | 🔒 100% Local | Medium |
 | **Azure OpenAI** | Cloud | GPT-4o, GPT-5, o1, o3 | $$$ | Cloud | Medium |
@@ -384,6 +385,47 @@ OPENROUTER_MODEL=deepseek/deepseek-coder            # $0.14/$0.28 per 1M tokens
 - ✅ **Rate limit pooling** across models
 
 See [openrouter.ai/models](https://openrouter.ai/models) for complete list with pricing.
+
+---
+
+### 3b. Eden AI (600+ Models, EU/GDPR)
+
+**Best for:** EU/GDPR-compliant access to 600+ models (OpenAI, Anthropic, Google, Mistral, …) through one OpenAI-compatible key. Works with both Lynkr's OpenAI-format path and Claude Code / Cursor / Codex passthrough.
+
+#### Configuration
+
+```env
+MODEL_PROVIDER=edenai
+EDENAI_API_KEY=your-edenai-key
+EDENAI_MODEL=anthropic/claude-sonnet-4-5
+EDENAI_ENDPOINT=https://api.edenai.run/v3/chat/completions
+```
+
+#### Getting an Eden AI API Key
+
+1. Visit [edenai.co](https://www.edenai.co) and create an account
+2. Open the dashboard → **API Keys**
+3. Create a key (a new organization is auto-created per account)
+4. Add credits (pay-as-you-go)
+
+#### Popular Models (`provider/model` naming)
+
+```env
+EDENAI_MODEL=anthropic/claude-sonnet-4-5     # Best for coding
+EDENAI_MODEL=openai/gpt-4o                    # General purpose
+EDENAI_MODEL=openai/gpt-4o-mini               # Cheap / fast (default)
+EDENAI_MODEL=google/gemini-2.5-flash          # Fast, long context
+```
+
+#### Benefits
+
+- ✅ **600+ models** through one OpenAI-compatible API
+- ✅ **EU-hosted / GDPR-compliant** option (differentiator vs US gateways)
+- ✅ **Both OpenAI- and Anthropic-compatible** endpoints (fits Claude Code passthrough)
+- ✅ **Full tool calling support**
+- ✅ **Pairs with tier routing** — cheap model for SIMPLE, frontier model for REASONING, one key
+
+See [docs.edenai.co](https://www.edenai.co/docs) for the model catalog and pricing.
 
 ---
 

--- a/src/api/openai-router.js
+++ b/src/api/openai-router.js
@@ -781,6 +781,21 @@ function getConfiguredProviders() {
     });
   }
 
+  // Check Eden AI (OpenAI-compatible gateway, EU/GDPR)
+  if (config.edenai?.apiKey) {
+    providers.push({
+      name: "edenai",
+      type: "edenai",
+      models: [
+        config.edenai.model || "openai/gpt-4o-mini",
+        "anthropic/claude-sonnet-4-5",
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "google/gemini-2.5-flash"
+      ]
+    });
+  }
+
   // Check Ollama
   if (config.ollama?.endpoint) {
     providers.push({
@@ -900,6 +915,9 @@ router.get("/models", (req, res) => {
         case "openrouter":
           embeddingModelId = embeddingConfig.model;
           break;
+        case "edenai":
+          embeddingModelId = embeddingConfig.model;
+          break;
         case "openai":
           embeddingModelId = embeddingConfig.model || "text-embedding-ada-002";
           break;
@@ -993,6 +1011,18 @@ function determineEmbeddingProvider(requestedModel = null) {
           endpoint: "https://openrouter.ai/api/v1/embeddings"
         };
 
+      case "edenai":
+        if (!config.edenai?.apiKey) {
+          logger.warn("EMBEDDINGS_PROVIDER=edenai but EDENAI_API_KEY not set");
+          return null;
+        }
+        return {
+          provider: "edenai",
+          model: requestedModel || config.edenai.embeddingsModel,
+          apiKey: config.edenai.apiKey,
+          endpoint: "https://api.edenai.run/v3/embeddings"
+        };
+
       case "openai":
         if (!config.openai?.apiKey) {
           logger.warn("EMBEDDINGS_PROVIDER=openai but OPENAI_API_KEY not set");
@@ -1016,6 +1046,15 @@ function determineEmbeddingProvider(requestedModel = null) {
       model: requestedModel || config.openrouter.embeddingsModel,
       apiKey: config.openrouter.apiKey,
       endpoint: "https://openrouter.ai/api/v1/embeddings"
+    };
+  }
+
+  if (chatProvider === "edenai" && config.edenai?.apiKey) {
+    return {
+      provider: "edenai",
+      model: requestedModel || config.edenai.embeddingsModel,
+      apiKey: config.edenai.apiKey,
+      endpoint: "https://api.edenai.run/v3/embeddings"
     };
   }
 
@@ -1336,6 +1375,11 @@ router.post("/embeddings", async (req, res) => {
 
         case "openrouter":
           embeddingResponse = await generateOpenRouterEmbeddings(inputs, embeddingConfig);
+          break;
+
+        case "edenai":
+          // Eden AI embeddings are OpenAI-compatible (Bearer + {model,input}).
+          embeddingResponse = await generateOpenAIEmbeddings(inputs, embeddingConfig);
           break;
 
         case "openai":

--- a/src/api/providers-handler.js
+++ b/src/api/providers-handler.js
@@ -124,6 +124,23 @@ function getConfiguredProviders() {
     });
   }
 
+  // Check Eden AI (OpenAI-compatible gateway, EU/GDPR)
+  if (config.edenai?.apiKey) {
+    providers.push({
+      name: "edenai",
+      type: "edenai",
+      baseUrl: "https://api.edenai.run/v3",
+      enabled: true,
+      models: [
+        { id: config.edenai.model || "openai/gpt-4o-mini", name: "Configured Model" },
+        { id: "anthropic/claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+        { id: "openai/gpt-4o", name: "GPT-4o" },
+        { id: "openai/gpt-4o-mini", name: "GPT-4o Mini" },
+        { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" }
+      ]
+    });
+  }
+
   // Check Ollama
   if (config.ollama?.endpoint) {
     providers.push({

--- a/src/clients/databricks.js
+++ b/src/clients/databricks.js
@@ -704,6 +704,71 @@ async function invokeOpenRouter(body, incomingHeaders = {}) {
   return performJsonRequest(endpoint, { headers, body: openRouterBody }, "OpenRouter");
 }
 
+// Eden AI is an OpenAI-compatible gateway (provider/model naming, EU/GDPR).
+// It speaks the same wire format as OpenRouter, so this mirrors invokeOpenRouter
+// and reuses the shared Anthropic<->OpenAI converters.
+async function invokeEdenAI(body, incomingHeaders = {}) {
+  if (!config.edenai?.endpoint || !config.edenai?.apiKey) {
+    throw new Error("Eden AI endpoint or API key is not configured.");
+  }
+
+  const {
+    convertAnthropicToolsToOpenRouter,
+    convertAnthropicMessagesToOpenRouter
+  } = require("./openrouter-utils");
+
+  const endpoint = config.edenai.endpoint;
+  const headers = {
+    "Authorization": `Bearer ${config.edenai.apiKey}`,
+    "Content-Type": "application/json"
+  };
+
+  // Convert messages and handle system message
+  const messages = convertAnthropicMessagesToOpenRouter(body.messages || []);
+
+  // Anthropic uses separate 'system' field, OpenAI needs it as first message
+  if (body.system) {
+    messages.unshift({
+      role: "system",
+      content: body.system
+    });
+  }
+
+  const edenAIBody = {
+    model: body._suggestionModeModel || body._tierModel || config.edenai.model,
+    messages,
+    temperature: body.temperature ?? 0.7,
+    max_tokens: body.max_tokens ?? 16384,
+    top_p: body.top_p ?? 1.0,
+    stream: body.stream ?? false
+  };
+
+  // Add tools - inject standard tools if client didn't send any (passthrough mode)
+  let toolsToSend = body.tools;
+  let toolsInjected = false;
+
+  if (!Array.isArray(toolsToSend) || toolsToSend.length === 0) {
+    toolsToSend = STANDARD_TOOLS;
+    toolsInjected = true;
+    logger.debug({
+      injectedToolCount: STANDARD_TOOLS.length,
+      injectedToolNames: STANDARD_TOOL_NAMES,
+      reason: "Client did not send tools (passthrough mode)"
+    }, "=== INJECTING STANDARD TOOLS (Eden AI) ===");
+  }
+
+  if (Array.isArray(toolsToSend) && toolsToSend.length > 0) {
+    edenAIBody.tools = convertAnthropicToolsToOpenRouter(toolsToSend);
+    logger.debug({
+      toolCount: toolsToSend.length,
+      toolNames: toolsToSend.map(t => t.name),
+      toolsInjected
+    }, "Sending tools to Eden AI");
+  }
+
+  return performJsonRequest(endpoint, { headers, body: edenAIBody }, "EdenAI");
+}
+
 function detectAzureFormat(url) {
   if (url.includes("/openai/responses")) return "responses";
   if (url.includes("/models/")) return "models";
@@ -2633,6 +2698,8 @@ async function invokeModel(body, options = {}) {
         return await invokeOllama(body, incomingHeaders);
       } else if (initialProvider === "openrouter") {
         return await invokeOpenRouter(body, incomingHeaders);
+      } else if (initialProvider === "edenai") {
+        return await invokeEdenAI(body, incomingHeaders);
       } else if (initialProvider === "openai") {
         return await invokeOpenAI(body, incomingHeaders);
       } else if (initialProvider === "llamacpp") {
@@ -2876,6 +2943,8 @@ async function invokeModel(body, options = {}) {
           return await invokeAzureAnthropic(body, incomingHeaders);
         } else if (fallbackProvider === "openrouter") {
           return await invokeOpenRouter(body, incomingHeaders);
+        } else if (fallbackProvider === "edenai") {
+          return await invokeEdenAI(body, incomingHeaders);
         } else if (fallbackProvider === "openai") {
           return await invokeOpenAI(body, incomingHeaders);
         } else if (fallbackProvider === "llamacpp") {

--- a/src/clients/prompt-cache-injection.js
+++ b/src/clients/prompt-cache-injection.js
@@ -114,6 +114,7 @@ function needsCacheInjection(provider) {
     'bedrock',
     'databricks',   // Databricks routes to Claude which supports caching
     'openrouter',   // OpenRouter forwards cache_control to underlying provider
+    'edenai',       // Eden AI forwards cache_control to underlying provider
   ]);
 
   return EXPLICIT_CACHE_PROVIDERS.has(provider);

--- a/src/clients/provider-capabilities.js
+++ b/src/clients/provider-capabilities.js
@@ -11,7 +11,7 @@ const NATIVE_THINKING_BEDROCK_MODELS = [
   "claude-haiku",
 ];
 
-const REASONING_CONTENT_PROVIDERS = new Set(["moonshot", "openrouter", "openai", "azure-openai"]);
+const REASONING_CONTENT_PROVIDERS = new Set(["moonshot", "openrouter", "edenai", "openai", "azure-openai"]);
 
 function supportsNativeThinking(providerType, model) {
   if (NATIVE_THINKING_PROVIDERS.has(providerType)) return true;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -62,7 +62,7 @@ function resolveConfigPath(targetPath) {
   return path.resolve(normalised);
 }
 
-const SUPPORTED_MODEL_PROVIDERS = new Set(["databricks", "azure-anthropic", "ollama", "openrouter", "azure-openai", "openai", "llamacpp", "lmstudio", "bedrock", "zai", "vertex", "moonshot"]);
+const SUPPORTED_MODEL_PROVIDERS = new Set(["databricks", "azure-anthropic", "ollama", "openrouter", "edenai", "azure-openai", "openai", "llamacpp", "lmstudio", "bedrock", "zai", "vertex", "moonshot"]);
 const rawModelProvider = (process.env.MODEL_PROVIDER ?? "databricks").toLowerCase();
 
 // Validate MODEL_PROVIDER early with a clear error message
@@ -96,6 +96,12 @@ const openRouterApiKey = process.env.OPENROUTER_API_KEY ?? null;
 const openRouterModel = process.env.OPENROUTER_MODEL ?? "openai/gpt-4o-mini";
 const openRouterEmbeddingsModel = process.env.OPENROUTER_EMBEDDINGS_MODEL ?? "openai/text-embedding-ada-002";
 const openRouterEndpoint = process.env.OPENROUTER_ENDPOINT ?? "https://openrouter.ai/api/v1/chat/completions";
+
+// Eden AI configuration (OpenAI-compatible v3 gateway — provider/model naming, EU/GDPR)
+const edenAIApiKey = process.env.EDENAI_API_KEY ?? null;
+const edenAIModel = process.env.EDENAI_MODEL ?? "openai/gpt-4o-mini";
+const edenAIEmbeddingsModel = process.env.EDENAI_EMBEDDINGS_MODEL ?? "openai/text-embedding-ada-002";
+const edenAIEndpoint = process.env.EDENAI_ENDPOINT ?? "https://api.edenai.run/v3/chat/completions";
 
 // Azure OpenAI configuration
 const azureOpenAIEndpoint = process.env.AZURE_OPENAI_ENDPOINT?.trim() || null;
@@ -336,7 +342,7 @@ const tiersConfigured = !!(
 if (fallbackEnabled && tiersConfigured) {
   const localProviders = ["ollama", "llamacpp", "lmstudio"];
   if (localProviders.includes(fallbackProvider)) {
-    throw new Error(`FALLBACK_PROVIDER cannot be '${fallbackProvider}' (local providers should not be fallbacks). Use cloud providers: databricks, azure-anthropic, azure-openai, openrouter, openai, bedrock`);
+    throw new Error(`FALLBACK_PROVIDER cannot be '${fallbackProvider}' (local providers should not be fallbacks). Use cloud providers: databricks, azure-anthropic, azure-openai, openrouter, edenai, openai, bedrock`);
   }
   let fallbackMisconfigured = false;
   if (fallbackProvider === "databricks" && (!rawBaseUrl || !apiKey)) {
@@ -584,6 +590,12 @@ var config = {
     model: openRouterModel,
     embeddingsModel: openRouterEmbeddingsModel,
     endpoint: openRouterEndpoint,
+  },
+  edenai: {
+    apiKey: edenAIApiKey,
+    model: edenAIModel,
+    embeddingsModel: edenAIEmbeddingsModel,
+    endpoint: edenAIEndpoint,
   },
   azureOpenAI: {
     endpoint: azureOpenAIEndpoint,
@@ -1013,6 +1025,8 @@ function reloadConfig() {
   config.ollama.model = process.env.OLLAMA_MODEL ?? "qwen2.5-coder:7b";
   config.openrouter.apiKey = process.env.OPENROUTER_API_KEY ?? null;
   config.openrouter.model = process.env.OPENROUTER_MODEL ?? "openai/gpt-4o-mini";
+  config.edenai.apiKey = process.env.EDENAI_API_KEY ?? null;
+  config.edenai.model = process.env.EDENAI_MODEL ?? "openai/gpt-4o-mini";
   config.azureOpenAI.apiKey = process.env.AZURE_OPENAI_API_KEY?.trim() || null;
   config.openai.apiKey = process.env.OPENAI_API_KEY?.trim() || null;
   config.bedrock.apiKey = process.env.AWS_BEDROCK_API_KEY?.trim() || null;

--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -13,6 +13,7 @@ function providerMeta() {
     'azure-anthropic': { type: 'cloud', configured: !!(c.azureAnthropic?.endpoint && c.azureAnthropic?.apiKey) },
     bedrock:           { type: 'cloud', configured: !!c.bedrock?.apiKey },
     openrouter:        { type: 'cloud', configured: !!c.openrouter?.apiKey },
+    edenai:            { type: 'cloud', configured: !!c.edenai?.apiKey },
     openai:            { type: 'cloud', configured: !!c.openai?.apiKey },
     'azure-openai':    { type: 'cloud', configured: !!(c.azureOpenAI?.endpoint && c.azureOpenAI?.apiKey) },
     vertex:            { type: 'cloud', configured: !!c.vertex?.projectId },

--- a/src/orchestrator/index.js
+++ b/src/orchestrator/index.js
@@ -43,6 +43,8 @@ function getDestinationUrl(providerType) {
       return config.azureOpenAI?.endpoint ?? 'unknown';
     case 'openrouter':
       return config.openrouter?.endpoint ?? 'unknown';
+    case 'edenai':
+      return config.edenai?.endpoint ?? 'unknown';
     case 'openai':
       return 'https://api.openai.com/v1/chat/completions';
     case 'llamacpp':
@@ -1318,8 +1320,8 @@ function sanitizePayload(payload) {
     if (Array.isArray(clean.tools) && clean.tools.length > 0) {
       clean.tools = ensureAnthropicToolFormat(clean.tools);
     }
-  } else if (providerType === "openrouter") {
-    // OpenRouter supports tools - keep them as-is
+  } else if (providerType === "openrouter" || providerType === "edenai") {
+    // OpenRouter / Eden AI (OpenAI-compatible) support tools - keep them as-is.
     // Tools are already in Anthropic format and will be converted by openrouter-utils
     if (!Array.isArray(clean.tools) || clean.tools.length === 0) {
       delete clean.tools;
@@ -1924,9 +1926,9 @@ IMPORTANT TOOL USAGE RULES:
   // Claude-family; an operator who switches HEADROOM_PROVIDER=openai gets the
   // analogous gate.
   const headroomProviderMap = {
-    'anthropic': new Set(['azure-anthropic', 'bedrock', 'vertex', 'openrouter']),
-    'openai':    new Set(['azure-openai', 'openai', 'openrouter']),
-    'google':    new Set(['vertex', 'openrouter']),
+    'anthropic': new Set(['azure-anthropic', 'bedrock', 'vertex', 'openrouter', 'edenai']),
+    'openai':    new Set(['azure-openai', 'openai', 'openrouter', 'edenai']),
+    'google':    new Set(['vertex', 'openrouter', 'edenai']),
   };
   const headroomProvider = process.env.HEADROOM_PROVIDER || 'anthropic';
   const headroomSafeProviders = headroomProviderMap[headroomProvider] || new Set();
@@ -2049,6 +2051,7 @@ IMPORTANT TOOL USAGE RULES:
     'bedrock',
     'vertex',
     'openrouter',
+    'edenai',
     'ollama',
     'openai',
     'azure-openai',
@@ -3107,7 +3110,7 @@ IMPORTANT TOOL USAGE RULES:
       if (Array.isArray(anthropicPayload?.content)) {
         anthropicPayload.content = policy.sanitiseContent(anthropicPayload.content);
       }
-    } else if (actualProvider === "openrouter") {
+    } else if (actualProvider === "openrouter" || actualProvider === "edenai") {
       const { convertOpenRouterResponseToAnthropic } = require("../clients/openrouter-utils");
 
       // Validate OpenRouter response has choices array before conversion

--- a/src/routing/index.js
+++ b/src/routing/index.js
@@ -67,6 +67,7 @@ function _enabledProviders() {
   if (config.azureAnthropic?.endpoint && config.azureAnthropic?.apiKey) out.push('azure-anthropic');
   if (config.bedrock?.apiKey) out.push('bedrock');
   if (config.openrouter?.apiKey) out.push('openrouter');
+  if (config.edenai?.apiKey) out.push('edenai');
   if (config.openai?.apiKey) out.push('openai');
   if (config.azureOpenAI?.endpoint && config.azureOpenAI?.apiKey) out.push('azure-openai');
   if (config.ollama?.endpoint) out.push('ollama');
@@ -108,6 +109,7 @@ function getBestCloudProvider() {
   if (config.azureAnthropic?.endpoint && config.azureAnthropic?.apiKey) return 'azure-anthropic';
   if (config.bedrock?.apiKey) return 'bedrock';
   if (config.openrouter?.apiKey) return 'openrouter';
+  if (config.edenai?.apiKey) return 'edenai';
   if (config.openai?.apiKey) return 'openai';
   if (config.azureOpenAI?.endpoint && config.azureOpenAI?.apiKey) return 'azure-openai';
 

--- a/src/routing/model-tiers.js
+++ b/src/routing/model-tiers.js
@@ -330,6 +330,8 @@ class ModelTierSelector {
         return config.ollama?.model || null;
       case 'openrouter':
         return config.openrouter?.model || null;
+      case 'edenai':
+        return config.edenai?.model || null;
       case 'llamacpp':
         return config.llamacpp?.model || null;
       case 'lmstudio':

--- a/test/edenai-integration.test.js
+++ b/test/edenai-integration.test.js
@@ -1,0 +1,109 @@
+const assert = require("assert");
+const { describe, it, beforeEach, afterEach } = require("node:test");
+
+// Eden AI is an OpenAI-compatible gateway (provider/model naming, EU/GDPR).
+// These tests mirror the OpenRouter provider wiring.
+describe("Eden AI provider", () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve("../src/config/index.js")];
+    delete require.cache[require.resolve("../src/clients/routing")];
+    delete require.cache[require.resolve("../src/routing/index.js")];
+    delete require.cache[require.resolve("../src/routing/model-tiers")];
+    delete require.cache[require.resolve("../src/clients/provider-capabilities")];
+
+    originalEnv = { ...process.env };
+    process.env.FALLBACK_PROVIDER = "databricks";
+    process.env.TIER_SIMPLE = "";
+    process.env.TIER_MEDIUM = "";
+    process.env.TIER_COMPLEX = "";
+    process.env.TIER_REASONING = "";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("config", () => {
+    it("populates config.edenai from EDENAI_* env with sensible defaults", () => {
+      process.env.MODEL_PROVIDER = "edenai";
+      process.env.EDENAI_API_KEY = "test-edenai-key";
+      const config = require("../src/config");
+
+      assert.strictEqual(config.edenai.apiKey, "test-edenai-key");
+      assert.strictEqual(config.edenai.model, "openai/gpt-4o-mini");
+      assert.strictEqual(config.edenai.endpoint, "https://api.edenai.run/v3/chat/completions");
+      assert.strictEqual(config.edenai.embeddingsModel, "openai/text-embedding-ada-002");
+    });
+
+    it("honours EDENAI_MODEL / EDENAI_ENDPOINT overrides", () => {
+      process.env.MODEL_PROVIDER = "edenai";
+      process.env.EDENAI_API_KEY = "test-edenai-key";
+      process.env.EDENAI_MODEL = "anthropic/claude-sonnet-4-5";
+      process.env.EDENAI_ENDPOINT = "https://api.eu.edenai.run/v3/chat/completions";
+      const config = require("../src/config");
+
+      assert.strictEqual(config.edenai.model, "anthropic/claude-sonnet-4-5");
+      assert.strictEqual(config.edenai.endpoint, "https://api.eu.edenai.run/v3/chat/completions");
+    });
+
+    it("accepts MODEL_PROVIDER=edenai (in SUPPORTED_MODEL_PROVIDERS)", () => {
+      process.env.MODEL_PROVIDER = "edenai";
+      process.env.EDENAI_API_KEY = "test-edenai-key";
+      assert.doesNotThrow(() => require("../src/config"));
+    });
+  });
+
+  describe("routing", () => {
+    it("returns edenai for static routing when MODEL_PROVIDER=edenai", async () => {
+      process.env.MODEL_PROVIDER = "edenai";
+      process.env.EDENAI_API_KEY = "test-edenai-key";
+
+      require("../src/config");
+      const routing = require("../src/clients/routing");
+
+      const payload = { messages: [{ role: "user", content: "test" }] };
+      const result = await routing.determineProviderSmart(payload);
+
+      assert.strictEqual(result.provider, "edenai");
+      assert.strictEqual(result.method, "static");
+    });
+  });
+
+  describe("capabilities", () => {
+    it("treats edenai as a reasoning_content provider (OpenAI-compatible)", () => {
+      const { supportsReasoningContent, getThinkingBehavior } =
+        require("../src/clients/provider-capabilities");
+      assert.strictEqual(supportsReasoningContent("edenai"), true);
+      assert.strictEqual(getThinkingBehavior("edenai"), "reasoning_content");
+    });
+  });
+
+  // Live end-to-end test — only runs when a real key is present AND EDENAI_LIVE=1.
+  // In CI, scope EDENAI_API_KEY to this step's env only (never at workflow/job level).
+  describe("live endpoint (gated)", () => {
+    it("returns an OpenAI-shaped completion from api.edenai.run/v3", async (t) => {
+      if (process.env.EDENAI_LIVE !== "1" || !process.env.EDENAI_API_KEY) {
+        t.skip("set EDENAI_LIVE=1 and EDENAI_API_KEY to run the live test");
+        return;
+      }
+      const res = await fetch("https://api.edenai.run/v3/chat/completions", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${process.env.EDENAI_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: process.env.EDENAI_MODEL || "openai/gpt-4o-mini",
+          messages: [{ role: "user", content: "Say the single word: pong" }],
+          max_tokens: 10,
+        }),
+      });
+      assert.strictEqual(res.status, 200);
+      const json = await res.json();
+      assert.ok(Array.isArray(json.choices) && json.choices.length > 0, "response has choices[]");
+      assert.strictEqual(typeof json.choices[0].message.content, "string");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds **Eden AI** as a native provider, mirroring the existing OpenRouter (OpenAI-compatible) path. Eden AI is an OpenAI-compatible gateway (`https://api.edenai.run/v3/chat/completions`, `provider/model` naming) giving one key + EU/GDPR-compliant access to 600+ models across OpenAI, Anthropic, Google, Mistral, etc. It exposes **both** OpenAI- and Anthropic-compatible endpoints, so it fits both Lynkr's OpenAI-format path and the Claude Code / Cursor / Codex passthrough, and pairs naturally with tier routing (cheap model for SIMPLE → frontier for REASONING, one key).

## What changed
- **Config** (`src/config/index.js`): `edenai` in `SUPPORTED_MODEL_PROVIDERS`, `config.edenai`, `EDENAI_API_KEY/MODEL/EMBEDDINGS_MODEL/ENDPOINT`, reload path.
- **Dispatch** (`src/clients/databricks.js`): `invokeEdenAI()` mirroring `invokeOpenRouter`, reusing the shared Anthropic↔OpenAI converters; initial + fallback branches.
- **Orchestrator** (`src/orchestrator/index.js`): endpoint lookup, tool passthrough, response conversion, headroom/caveman provider sets.
- **API/embeddings** (`src/api/openai-router.js`, `src/api/providers-handler.js`): provider listing + `/v3/embeddings` parity.
- **Routing/capabilities**: `src/routing/index.js`, `src/routing/model-tiers.js`, `src/clients/provider-capabilities.js` (reasoning_content), `src/clients/prompt-cache-injection.js`, `src/dashboard/api.js`.
- **UX/docs**: `bin/lynkr-init.js` wizard entry, `.env.example`, `documentation/providers.md`.
- **Tests/CI**: `test/edenai-integration.test.js`, `.github/workflows/edenai-integration.yml` (EDENAI_API_KEY secret scoped to the live-test step only; self-skips on fork PRs).

15 files, +401 / −10.

## Usage
```env
MODEL_PROVIDER=edenai
EDENAI_API_KEY=your-key
EDENAI_MODEL=anthropic/claude-sonnet-4-5
# or per tier:
TIER_SIMPLE=edenai:openai/gpt-4o-mini
TIER_REASONING=edenai:anthropic/claude-opus-4-8
```

## Testing
Live-tested against `api.edenai.run/v3` with a real key:
- Chat completion (200, OpenAI shape) ✅
- Tool-calling on `openai/gpt-4o`, `gpt-4o-mini`, `anthropic/claude-opus-4-8`, `claude-haiku-4-5` → `finish_reason: tool_calls` ✅
- Streaming (SSE) ✅
- `node --test test/edenai-integration.test.js` (config/routing/capabilities) ✅

## Notes
- Implemented as an OpenAI-compatible provider; no new response-conversion code (reuses `openrouter-utils`).
- Reviewer: the diff intentionally follows the OpenRouter provider 1:1 for maintainability.