### PR TITLE
fix: regenerate package-lock.json against the public npm registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Guard: the lockfile must only reference the public npm registry.
+      # A private/corporate mirror URL in `resolved` breaks `npm install` /
+      # `npm ci` / Docker builds for everyone outside that network (this
+      # shipped once — 100 npm.devsnc.com URLs made from-source installs 403
+      # for the public). Recurs silently whenever someone on a corporate
+      # network runs `npm install` and commits the lockfile.
+      - name: Lockfile uses public registry only
+        run: |
+          if grep -oE '"resolved": "https://[^/"]*' package-lock.json | grep -v 'registry.npmjs.org'; then
+            echo "::error::package-lock.json contains non-public registry URLs (see above). Regenerate off the corporate network: rm -rf node_modules package-lock.json && npm install"
+            exit 1
+          fi
+        timeout-minutes: 1
+
       - uses: pnpm/action-setup@v4
         with:
           version: 9

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@toon-format/toon": "^2.1.0",
         "cockatiel": "^3.2.1",
         "diff": "^5.2.0",
-        "dockerode": "^5.0.1",
         "dotenv": "^16.4.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.2.1",
@@ -64,46 +63,43 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -178,15 +174,15 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.5.3",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -254,29 +250,29 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/ansi/-/ansi-2.0.5.tgz",
-      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+      "integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
-      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
+      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -288,17 +284,17 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.11",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/confirm/-/confirm-6.0.11.tgz",
-      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
+      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -310,22 +306,22 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.8",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/core/-/core-11.1.8.tgz",
-      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
+      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
         "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -337,18 +333,18 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/editor/-/editor-5.1.0.tgz",
-      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
+      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/external-editor": "^3.0.0",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/external-editor": "^3.0.5",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -360,17 +356,17 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.12",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/expand/-/expand-5.0.12.tgz",
-      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
+      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -382,9 +378,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "3.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
-      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+      "integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -392,7 +388,7 @@
         "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -404,27 +400,27 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/figures/-/figures-2.0.5.tgz",
-      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+      "integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.11",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/input/-/input-5.0.11.tgz",
-      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
+      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -436,17 +432,17 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.11",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/number/-/number-4.0.11.tgz",
-      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
+      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -458,18 +454,18 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.11",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/password/-/password-5.0.11.tgz",
-      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
+      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -481,25 +477,25 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.4.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/prompts/-/prompts-8.4.1.tgz",
-      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
+      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.3",
-        "@inquirer/confirm": "^6.0.11",
-        "@inquirer/editor": "^5.1.0",
-        "@inquirer/expand": "^5.0.12",
-        "@inquirer/input": "^5.0.11",
-        "@inquirer/number": "^4.0.11",
-        "@inquirer/password": "^5.0.11",
-        "@inquirer/rawlist": "^5.2.7",
-        "@inquirer/search": "^4.1.7",
-        "@inquirer/select": "^5.1.3"
+        "@inquirer/checkbox": "^5.2.4",
+        "@inquirer/confirm": "^6.3.1",
+        "@inquirer/editor": "^5.3.2",
+        "@inquirer/expand": "^5.1.4",
+        "@inquirer/input": "^5.1.5",
+        "@inquirer/number": "^4.2.2",
+        "@inquirer/password": "^5.2.1",
+        "@inquirer/rawlist": "^5.3.4",
+        "@inquirer/search": "^4.3.2",
+        "@inquirer/select": "^5.2.4"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -511,17 +507,17 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.7",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
-      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
+      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -533,18 +529,18 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.7",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/search/-/search-4.1.7.tgz",
-      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
+      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -556,19 +552,19 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/select/-/select-5.1.3.tgz",
-      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
+      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/ansi": "^2.0.8",
+        "@inquirer/core": "^12.0.2",
+        "@inquirer/figures": "^2.0.9",
+        "@inquirer/type": "4.1.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -580,13 +576,13 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@inquirer/type/-/type-4.0.5.tgz",
-      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+      "integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -609,48 +605,56 @@
       }
     },
     "node_modules/@napi-rs/cli": {
-      "version": "3.6.2",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/cli/-/cli-3.6.2.tgz",
-      "integrity": "sha512-jy5rABUh9tbE/vPRzw9kGzGuqZiVslyDQUV8LkvjzqVX/oJMN7g0U1uhtr9L3W1H+iRM/urXHXUf+CE4n8FvLA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.9.0.tgz",
+      "integrity": "sha512-ZlerYOCLgVdaqbVDt8+uQxmU9j8bKMVFcYo6zRHJJHTO9jN5060+y953aIVc/0zkVSKq+fHjDAtTGOrbxpeZCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "^8.0.0",
+        "@inquirer/prompts": "^8.5.2",
         "@napi-rs/cross-toolchain": "^1.0.3",
-        "@napi-rs/wasm-tools": "^1.0.1",
+        "@napi-rs/wasm-tools": "^1.1.0",
         "@octokit/rest": "^22.0.1",
         "clipanion": "^4.0.0-rc.4",
         "colorette": "^2.0.20",
-        "emnapi": "^1.9.1",
-        "es-toolkit": "^1.41.0",
-        "js-yaml": "^4.1.0",
-        "obug": "^2.0.0",
-        "semver": "^7.7.3",
-        "typanion": "^3.14.0"
+        "es-toolkit": "^1.47.0",
+        "js-yaml": "^4.2.0",
+        "obug": "^2.1.2",
+        "semver": "^7.8.2",
+        "typanion": "^3.14.0",
+        "typescript": "^6.0.3"
       },
       "bin": {
         "napi": "dist/cli.js",
         "napi-raw": "cli.mjs"
       },
       "engines": {
-        "node": ">= 16"
+        "node": "^20.17.0 || ^22.13.0 || >= 23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4",
+        "emnapi": "^1.7.1 || ^2.0.0-alpha.4"
       },
       "peerDependenciesMeta": {
+        "@emnapi/core": {
+          "optional": true
+        },
         "@emnapi/runtime": {
+          "optional": true
+        },
+        "emnapi": {
           "optional": true
         }
       }
     },
     "node_modules/@napi-rs/cross-toolchain": {
       "version": "1.0.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/cross-toolchain/-/cross-toolchain-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cross-toolchain/-/cross-toolchain-1.0.3.tgz",
       "integrity": "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg==",
       "dev": true,
       "license": "MIT",
@@ -710,42 +714,42 @@
       }
     },
     "node_modules/@napi-rs/lzma": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma/-/lzma-1.4.5.tgz",
-      "integrity": "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.5.1.tgz",
+      "integrity": "sha512-sgOZ89+y8cDbY+3WbzR8CtIhCuFRWotZ9/2PjPVDJHz6np5KFTAev0DrwiyTJTgFsCRDhfGlbmhMgyhHbWdZ6g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/lzma-android-arm-eabi": "1.4.5",
-        "@napi-rs/lzma-android-arm64": "1.4.5",
-        "@napi-rs/lzma-darwin-arm64": "1.4.5",
-        "@napi-rs/lzma-darwin-x64": "1.4.5",
-        "@napi-rs/lzma-freebsd-x64": "1.4.5",
-        "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5",
-        "@napi-rs/lzma-linux-arm64-gnu": "1.4.5",
-        "@napi-rs/lzma-linux-arm64-musl": "1.4.5",
-        "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5",
-        "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5",
-        "@napi-rs/lzma-linux-s390x-gnu": "1.4.5",
-        "@napi-rs/lzma-linux-x64-gnu": "1.4.5",
-        "@napi-rs/lzma-linux-x64-musl": "1.4.5",
-        "@napi-rs/lzma-wasm32-wasi": "1.4.5",
-        "@napi-rs/lzma-win32-arm64-msvc": "1.4.5",
-        "@napi-rs/lzma-win32-ia32-msvc": "1.4.5",
-        "@napi-rs/lzma-win32-x64-msvc": "1.4.5"
+        "@napi-rs/lzma-android-arm-eabi": "1.5.1",
+        "@napi-rs/lzma-android-arm64": "1.5.1",
+        "@napi-rs/lzma-darwin-arm64": "1.5.1",
+        "@napi-rs/lzma-darwin-x64": "1.5.1",
+        "@napi-rs/lzma-freebsd-x64": "1.5.1",
+        "@napi-rs/lzma-linux-arm-gnueabihf": "1.5.1",
+        "@napi-rs/lzma-linux-arm64-gnu": "1.5.1",
+        "@napi-rs/lzma-linux-arm64-musl": "1.5.1",
+        "@napi-rs/lzma-linux-ppc64-gnu": "1.5.1",
+        "@napi-rs/lzma-linux-riscv64-gnu": "1.5.1",
+        "@napi-rs/lzma-linux-s390x-gnu": "1.5.1",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@napi-rs/lzma-linux-x64-musl": "1.5.1",
+        "@napi-rs/lzma-wasm32-wasi": "1.5.1",
+        "@napi-rs/lzma-win32-arm64-msvc": "1.5.1",
+        "@napi-rs/lzma-win32-ia32-msvc": "1.5.1",
+        "@napi-rs/lzma-win32-x64-msvc": "1.5.1"
       }
     },
     "node_modules/@napi-rs/lzma-android-arm-eabi": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.4.5.tgz",
-      "integrity": "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.5.1.tgz",
+      "integrity": "sha512-sahBe4ko2Z69NPTddaX6ZgbQZu9SDoITxw1S3dWl1gAGynZG34qHHCT8UaUMFxf3h3zMhCJjEzz4basaBxiTuQ==",
       "cpu": [
         "arm"
       ],
@@ -756,13 +760,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-android-arm64": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.4.5.tgz",
-      "integrity": "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.5.1.tgz",
+      "integrity": "sha512-7tkQAJJuBHxAxiEBNFgSTpvrtGpbwZYYJUSOmGEK3OfbdbNeoT2rdBxpM/gY1s+itEVbtOSlpaRPPG19MnwOzA==",
       "cpu": [
         "arm64"
       ],
@@ -773,13 +777,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-darwin-arm64": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.4.5.tgz",
-      "integrity": "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.5.1.tgz",
+      "integrity": "sha512-XWX8gtF+GHGk3nH3Wm3QUZNcxw9QHsFVZz3MzVLhWWHhceede1J4/vD+3dj3E1iKB9G6mualaZxOoD08R3E+7g==",
       "cpu": [
         "arm64"
       ],
@@ -790,13 +794,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-darwin-x64": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.4.5.tgz",
-      "integrity": "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.5.1.tgz",
+      "integrity": "sha512-CfsqUpMTI1z8enrA/b+GcHM6YDI8D0kqCiqPYEnst4rbOABQ9KZ92ybTTNnlnZ7A017WoMZKUEWc36KXDwi0xg==",
       "cpu": [
         "x64"
       ],
@@ -807,13 +811,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-freebsd-x64": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.4.5.tgz",
-      "integrity": "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.5.1.tgz",
+      "integrity": "sha512-bTyNfg90FXIgE61U7l14aMmVOqRQ6AyP5JMT3jmCStaZI18apLNPdzZ8i7yqxZfKvRMVfPjE2brXIw27c+RRgA==",
       "cpu": [
         "x64"
       ],
@@ -824,13 +828,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.4.5.tgz",
-      "integrity": "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.5.1.tgz",
+      "integrity": "sha512-vNE+D8nrw+eOkBsdKCsmDhowDV3pIMKXEhedvXfbgrWbrO7GlZJH+RXL+X+RYLxGwi8Ym61ZMt15sIOnNmh9Sw==",
       "cpu": [
         "arm"
       ],
@@ -841,132 +845,153 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-arm64-gnu": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.4.5.tgz",
-      "integrity": "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.5.1.tgz",
+      "integrity": "sha512-csUem4WgoKGTprv/pOPm9UIWbb+hrfUwYXefpTHPAEGVFLl5behEFabisJ7FtihCa3yG2Efcl+yw25rlhhrIYw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-arm64-musl": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.4.5.tgz",
-      "integrity": "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.5.1.tgz",
+      "integrity": "sha512-kB/xhlVN1eLvVmDJSKZEjp5Gg2xDYexNrB5jwpSMbOkeGS6N9AasByPBg5VqCpMYC+zZi7DM458DRhtWYhqXTQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-ppc64-gnu": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.4.5.tgz",
-      "integrity": "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.5.1.tgz",
+      "integrity": "sha512-s28RW0W1yBWQc1nbPdF7tp14koqslY3ZWLVI8uaanX292Dc6ezd4NPVwxEoCNBVON/oD7BmUbWGtyFvmm7dQ5A==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-riscv64-gnu": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.4.5.tgz",
-      "integrity": "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.5.1.tgz",
+      "integrity": "sha512-+lGNwYlIN14YPMTNvYtIJJqHFevDTd6Juw/1NmXbWx/iRd/LLrjhlM/yluMX6pxs6NkOGsuuEXJJrbbEUS59OQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-s390x-gnu": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.4.5.tgz",
-      "integrity": "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.5.1.tgz",
+      "integrity": "sha512-PB44FFWWFrLeQowhcep1hPD1YcLqKlnnY60RMU74qrxTlr4YGEyzeMItJqh2uivBfv9kQScOF/B0J9+Vab/oyw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.4.5.tgz",
-      "integrity": "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-musl": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.4.5.tgz",
-      "integrity": "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.5.1.tgz",
+      "integrity": "sha512-I3nsYrWtrW9JpeCr+mkJIVDt0HY3m6qVUBs5vTtoIvJQxwqf1PBXSy5IS7T53ksQFH2kd2UX8rLxJ7B4WISpZg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-wasm32-wasi": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.4.5.tgz",
-      "integrity": "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.5.1.tgz",
+      "integrity": "sha512-gy3wwPBa6+XEyA4fUzq6CClrXA1ajXjuVf5zbnHytJRgoHznj+mvpU3+co2fxXwqTCmIpn6KrzqH5bRDztBPhA==",
       "cpu": [
         "wasm32"
       ],
@@ -974,16 +999,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.4.5.tgz",
-      "integrity": "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.5.1.tgz",
+      "integrity": "sha512-dK+huOsHiyH6oJjij+cnjqFCakk2HgWmpI12Xm4pLUyPphe4ebYoJBgehaNAxprmjFqBQ7nL95YPVz9BHyqmPg==",
       "cpu": [
         "arm64"
       ],
@@ -994,13 +1021,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-win32-ia32-msvc": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.4.5.tgz",
-      "integrity": "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.5.1.tgz",
+      "integrity": "sha512-dGE8L+0EQ+GyU9ap9InqB/t/PmPG/bLj918q7OsJ29FuTdn8fK4OX3U4IQZhylHIA+/dQ/SXJk5n4yfah2XVvA==",
       "cpu": [
         "ia32"
       ],
@@ -1011,13 +1038,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/lzma-win32-x64-msvc": {
-      "version": "1.4.5",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.4.5.tgz",
-      "integrity": "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.5.1.tgz",
+      "integrity": "sha512-EKW4t/iqdCT/xnd5t9oXLvVER/PMNAWXKqUAl3fgvUcOILeZIIht77/dVnfFcc9htA/DCBXC/6YQWdW+LusjFA==",
       "cpu": [
         "x64"
       ],
@@ -1028,41 +1055,41 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/tar": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar/-/tar-1.1.0.tgz",
-      "integrity": "sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar/-/tar-1.1.1.tgz",
+      "integrity": "sha512-p6q2HhUc5vwH1CNwfOcrhLoxfgn8ust8Sqlfx+sA4VzAcp1cMbvbkl99tZZlDqOjCHgQNSiTfk/yWPjl/D42qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@napi-rs/tar-android-arm-eabi": "1.1.0",
-        "@napi-rs/tar-android-arm64": "1.1.0",
-        "@napi-rs/tar-darwin-arm64": "1.1.0",
-        "@napi-rs/tar-darwin-x64": "1.1.0",
-        "@napi-rs/tar-freebsd-x64": "1.1.0",
-        "@napi-rs/tar-linux-arm-gnueabihf": "1.1.0",
-        "@napi-rs/tar-linux-arm64-gnu": "1.1.0",
-        "@napi-rs/tar-linux-arm64-musl": "1.1.0",
-        "@napi-rs/tar-linux-ppc64-gnu": "1.1.0",
-        "@napi-rs/tar-linux-s390x-gnu": "1.1.0",
-        "@napi-rs/tar-linux-x64-gnu": "1.1.0",
-        "@napi-rs/tar-linux-x64-musl": "1.1.0",
-        "@napi-rs/tar-wasm32-wasi": "1.1.0",
-        "@napi-rs/tar-win32-arm64-msvc": "1.1.0",
-        "@napi-rs/tar-win32-ia32-msvc": "1.1.0",
-        "@napi-rs/tar-win32-x64-msvc": "1.1.0"
+        "@napi-rs/tar-android-arm-eabi": "1.1.1",
+        "@napi-rs/tar-android-arm64": "1.1.1",
+        "@napi-rs/tar-darwin-arm64": "1.1.1",
+        "@napi-rs/tar-darwin-x64": "1.1.1",
+        "@napi-rs/tar-freebsd-x64": "1.1.1",
+        "@napi-rs/tar-linux-arm-gnueabihf": "1.1.1",
+        "@napi-rs/tar-linux-arm64-gnu": "1.1.1",
+        "@napi-rs/tar-linux-arm64-musl": "1.1.1",
+        "@napi-rs/tar-linux-ppc64-gnu": "1.1.1",
+        "@napi-rs/tar-linux-s390x-gnu": "1.1.1",
+        "@napi-rs/tar-linux-x64-gnu": "1.1.1",
+        "@napi-rs/tar-linux-x64-musl": "1.1.1",
+        "@napi-rs/tar-wasm32-wasi": "1.1.1",
+        "@napi-rs/tar-win32-arm64-msvc": "1.1.1",
+        "@napi-rs/tar-win32-ia32-msvc": "1.1.1",
+        "@napi-rs/tar-win32-x64-msvc": "1.1.1"
       }
     },
     "node_modules/@napi-rs/tar-android-arm-eabi": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-android-arm-eabi/-/tar-android-arm-eabi-1.1.0.tgz",
-      "integrity": "sha512-h2Ryndraj/YiKgMV/r5by1cDusluYIRT0CaE0/PekQ4u+Wpy2iUVqvzVU98ZPnhXaNeYxEvVJHNGafpOfaD0TA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-android-arm-eabi/-/tar-android-arm-eabi-1.1.1.tgz",
+      "integrity": "sha512-cAhnA10cSusAUbcE9HtjQY/tZ9BH/0w2sKtRcQc94TzIlnm7QSr1htJSd/PPrbWNPtrv1orXb2CkrHlVlbnlHA==",
       "cpu": [
         "arm"
       ],
@@ -1077,9 +1104,9 @@
       }
     },
     "node_modules/@napi-rs/tar-android-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-android-arm64/-/tar-android-arm64-1.1.0.tgz",
-      "integrity": "sha512-DJFyQHr1ZxNZorm/gzc1qBNLF/FcKzcH0V0Vwan5P+o0aE2keQIGEjJ09FudkF9v6uOuJjHCVDdK6S6uHtShAw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-android-arm64/-/tar-android-arm64-1.1.1.tgz",
+      "integrity": "sha512-EslUWHCDBY/g5abTPBiHLsMaML4GagV0TXLm5WL9hAjx/DDtlxz9fegMb77RJ+f7nFLOIsUxF/3QWFvgOT0sMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1094,9 +1121,9 @@
       }
     },
     "node_modules/@napi-rs/tar-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-darwin-arm64/-/tar-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-Zz2sXRzjIX4e532zD6xm2SjXEym6MkvfCvL2RMpG2+UwNVDVscHNcz3d47Pf3sysP2e2af7fBB3TIoK2f6trPw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-darwin-arm64/-/tar-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-+A42/6ES5G9CQ35BOwzwA+WBjLID28r2jNPgc0dteD2hhClIhng0mva7D2ujUlXBNmgNOsr1LHn3stA4uTf4NQ==",
       "cpu": [
         "arm64"
       ],
@@ -1111,9 +1138,9 @@
       }
     },
     "node_modules/@napi-rs/tar-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-darwin-x64/-/tar-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-EI+CptIMNweT0ms9S3mkP/q+J6FNZ1Q6pvpJOEcWglRfyfQpLqjlC0O+dptruTPE8VamKYuqdjxfqD8hifZDOA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-darwin-x64/-/tar-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-RYtE8w1dkEvj8hSJCDV5Jw0Rz2i13fsM7u893zv5O9n/4Ad5GNsw/f4RQ7/0YGSFaenkVxqPFrjmEvUHlKzsrg==",
       "cpu": [
         "x64"
       ],
@@ -1128,9 +1155,9 @@
       }
     },
     "node_modules/@napi-rs/tar-freebsd-x64": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-freebsd-x64/-/tar-freebsd-x64-1.1.0.tgz",
-      "integrity": "sha512-J0PIqX+pl6lBIAckL/c87gpodLbjZB1OtIK+RDscKC9NLdpVv6VGOxzUV/fYev/hctcE8EfkLbgFOfpmVQPg2g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-freebsd-x64/-/tar-freebsd-x64-1.1.1.tgz",
+      "integrity": "sha512-rEepBvCJUwcuvUYkY83e8aot8RsR5Jcnal4PsG3tbWGKW1yAvcXhyMXf0fN6ZGpVRZFnB+FJqDyBxvsCPEXKhw==",
       "cpu": [
         "x64"
       ],
@@ -1145,9 +1172,9 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-arm-gnueabihf": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-arm-gnueabihf/-/tar-linux-arm-gnueabihf-1.1.0.tgz",
-      "integrity": "sha512-SLgIQo3f3EjkZ82ZwvrEgFvMdDAhsxCYjyoSuWfHCz0U16qx3SuGCp8+FYOPYCECHN3ZlGjXnoAIt9ERd0dEUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm-gnueabihf/-/tar-linux-arm-gnueabihf-1.1.1.tgz",
+      "integrity": "sha512-an1bJdfyhI5FpZYyTQ20mrqwR+a676i8GkaYc4Uy12dH/a7TJIfrK6Qa2Gm46arZvxUvx56qxoRKXbpOjUPvwA==",
       "cpu": [
         "arm"
       ],
@@ -1162,13 +1189,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-arm64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-arm64-gnu/-/tar-linux-arm64-gnu-1.1.0.tgz",
-      "integrity": "sha512-d014cdle52EGaH6GpYTQOP9Py7glMO1zz/+ynJPjjzYFSxvdYx0byrjumZk2UQdIyGZiJO2MEFpCkEEKFSgPYA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm64-gnu/-/tar-linux-arm64-gnu-1.1.1.tgz",
+      "integrity": "sha512-w++Vtx36T2yHTKws7GVnmHHcUT1ybB59xLWSh9A8bwEpJVG4dG7Qub9mFe5cpcbfrJ+XP2mKKxC3oUJSunK3iQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,13 +1209,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-arm64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-arm64-musl/-/tar-linux-arm64-musl-1.1.0.tgz",
-      "integrity": "sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-arm64-musl/-/tar-linux-arm64-musl-1.1.1.tgz",
+      "integrity": "sha512-Rh6UFhNtj3i4deJHOBINFIeRL0072mgbeyuK5rl1HokKnNoMKx8qKIZNEzBTTqpogMfDHWGvzyTQdnVxes5dpA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1196,13 +1229,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-ppc64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-ppc64-gnu/-/tar-linux-ppc64-gnu-1.1.0.tgz",
-      "integrity": "sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-ppc64-gnu/-/tar-linux-ppc64-gnu-1.1.1.tgz",
+      "integrity": "sha512-Cp+AxFbv9zcyAXtnzQi0OzmgDnQgy2w9D4Ubr+iwzMtVgJcztzcEoCcCrN1k2ATdEB01LX2Vb49IaocGOZhC9Q==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1213,13 +1249,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-s390x-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-s390x-gnu/-/tar-linux-s390x-gnu-1.1.0.tgz",
-      "integrity": "sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-s390x-gnu/-/tar-linux-s390x-gnu-1.1.1.tgz",
+      "integrity": "sha512-ZyscC3SYKTBWyDRYjLOKAd5TyJ7q0KACRdQ8bWrb3rgrra1CCIJD66CsGTH6Dh0AVSdfLwZ8MfIIXU6+14BMjQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,13 +1269,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-x64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-x64-gnu/-/tar-linux-x64-gnu-1.1.0.tgz",
-      "integrity": "sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-x64-gnu/-/tar-linux-x64-gnu-1.1.1.tgz",
+      "integrity": "sha512-LlIv+zg4fiOQge9LQX/ieBdRWE2fhVDjCTHxnunZkbugNmdhdelxWf1RpZb/6ZujWpNF4LPu4N/MW7ygg2oYAQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1247,13 +1289,16 @@
       }
     },
     "node_modules/@napi-rs/tar-linux-x64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-linux-x64-musl/-/tar-linux-x64-musl-1.1.0.tgz",
-      "integrity": "sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-linux-x64-musl/-/tar-linux-x64-musl-1.1.1.tgz",
+      "integrity": "sha512-gZBeoKLjanOVj55qk4EMu13P2i9M0SuINmlGQkOxm1niIJofexzddHUYtqO5o/5QqtyL8lADmAcZplLILMLhHA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1264,9 +1309,9 @@
       }
     },
     "node_modules/@napi-rs/tar-wasm32-wasi": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-wasm32-wasi/-/tar-wasm32-wasi-1.1.0.tgz",
-      "integrity": "sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-wasm32-wasi/-/tar-wasm32-wasi-1.1.1.tgz",
+      "integrity": "sha512-rwtQ1Mdt/ft6g6I54fJzbUeLspl4yTwj6I3UJ6mitKnrN42soJkcDrdh3Y/FGvlpqZTad2YMQ96fGJl3EtAm2Q==",
       "cpu": [
         "wasm32"
       ],
@@ -1274,16 +1319,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@napi-rs/tar-win32-arm64-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-win32-arm64-msvc/-/tar-win32-arm64-msvc-1.1.0.tgz",
-      "integrity": "sha512-vfpG71OB0ijtjemp3WTdmBKJm9R70KM8vsSExMsIQtV0lVzP07oM1CW6JbNRPXNLhRoue9ofYLiUDk8bE0Hckg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-arm64-msvc/-/tar-win32-arm64-msvc-1.1.1.tgz",
+      "integrity": "sha512-30PVp1AehRpfwxmv5wI4cg0yj3WmWBsZ+1QnLGnvEELu7Eu/+dhNU0nrmhI7VfPgLwSRK2eg9DQTB3tP7Wv9bA==",
       "cpu": [
         "arm64"
       ],
@@ -1298,9 +1345,9 @@
       }
     },
     "node_modules/@napi-rs/tar-win32-ia32-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-win32-ia32-msvc/-/tar-win32-ia32-msvc-1.1.0.tgz",
-      "integrity": "sha512-hGPyPW60YSpOSgzfy68DLBHgi6HxkAM+L59ZZZPMQ0TOXjQg+p2EW87+TjZfJOkSpbYiEkULwa/f4a2hcVjsqQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-ia32-msvc/-/tar-win32-ia32-msvc-1.1.1.tgz",
+      "integrity": "sha512-aI3/rmz+izUChiSeaPxcasAOxhf3FpJNuIHMXlxS/vpW+HIxUsSDR5+XV61PEG5DL4L/75iENVUxmSGM5l2yaw==",
       "cpu": [
         "ia32"
       ],
@@ -1315,9 +1362,9 @@
       }
     },
     "node_modules/@napi-rs/tar-win32-x64-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/tar-win32-x64-msvc/-/tar-win32-x64-msvc-1.1.0.tgz",
-      "integrity": "sha512-L6Ed1DxXK9YSCMyvpR8MiNAyKNkQLjsHsHK9E0qnHa8NzLFqzDKhvs5LfnWxM2kJ+F7m/e5n9zPm24kHb3LsVw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-x64-msvc/-/tar-win32-x64-msvc-1.1.1.tgz",
+      "integrity": "sha512-yJsB2IsrODQVLKbm2Fg1nHiVRbEj49mSPbj4x7JPZWJI0jGVPjohE2Sif0FBbx8OxsVoUODvS0BwksZZ8jl/OA==",
       "cpu": [
         "x64"
       ],
@@ -1332,53 +1379,56 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@napi-rs/wasm-tools": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools/-/wasm-tools-1.0.1.tgz",
-      "integrity": "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.1.0.tgz",
+      "integrity": "sha512-VjHyKEqXAwYZK+HY7iJctYvRm3TFEbaQxeZwvAG1QRkoo1a39phMY8J6x9tUEqJI03W6MysB8F2jacI6wvcx+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       },
       "optionalDependencies": {
-        "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1",
-        "@napi-rs/wasm-tools-android-arm64": "1.0.1",
-        "@napi-rs/wasm-tools-darwin-arm64": "1.0.1",
-        "@napi-rs/wasm-tools-darwin-x64": "1.0.1",
-        "@napi-rs/wasm-tools-freebsd-x64": "1.0.1",
-        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1",
-        "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1",
-        "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1",
-        "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1",
-        "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1",
-        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1",
-        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1",
-        "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1"
+        "@napi-rs/wasm-tools-android-arm-eabi": "1.1.0",
+        "@napi-rs/wasm-tools-android-arm64": "1.1.0",
+        "@napi-rs/wasm-tools-darwin-arm64": "1.1.0",
+        "@napi-rs/wasm-tools-darwin-x64": "1.1.0",
+        "@napi-rs/wasm-tools-freebsd-x64": "1.1.0",
+        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.1.0",
+        "@napi-rs/wasm-tools-linux-arm64-musl": "1.1.0",
+        "@napi-rs/wasm-tools-linux-x64-gnu": "1.1.0",
+        "@napi-rs/wasm-tools-linux-x64-musl": "1.1.0",
+        "@napi-rs/wasm-tools-wasm32-wasi": "1.1.0",
+        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.1.0",
+        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.1.0",
+        "@napi-rs/wasm-tools-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm-eabi": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.0.1.tgz",
-      "integrity": "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.1.0.tgz",
+      "integrity": "sha512-p6J8PB59I8d/XItXB/go5JH6nKW+xIbpzaL43EBTV0hi7mrS/Z4gs+MsB04ZrlqZN29BdZV8fChRyasuXLhRaA==",
       "cpu": [
         "arm"
       ],
@@ -1389,13 +1439,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.1.0.tgz",
+      "integrity": "sha512-lWoKN3suypeBSCIRPIw+++sH9V2K6nQkhtdt1opu7XY3v9JwLs6Gw063HWRqkNjphlYpkd/Qy8XcfSPGbJj7nQ==",
       "cpu": [
         "arm64"
       ],
@@ -1406,13 +1456,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-jfw5vyNDUf6oe0kP8lMveFN9U7cLk1cUosS7uMIfw/xmqmopYfKQ198DAx2g/6aEF7Tm+CqER2gpMpYKui30LA==",
       "cpu": [
         "arm64"
       ],
@@ -1423,13 +1473,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-R+pjeudAB7BYdH1vKkOJM61Tfv5jB6uXkxmFscYd+KKpdUpWBlNG+s4hr0w4i1rMBM91VhIAETZn2pz+MDHK9A==",
       "cpu": [
         "x64"
       ],
@@ -1440,13 +1490,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.1.0.tgz",
+      "integrity": "sha512-hQJTe+aazrT++Vgm6I4lUd9099ItUCFYdd+aKg6Ys6nax6d/cZ1barDLTwA2lwOoVDsXMekJI/FOL6ZvVlIYBg==",
       "cpu": [
         "x64"
       ],
@@ -1457,81 +1507,93 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-1TAXJxUHsWGar90k3W/MknavvBMwOWzjh7Q6Spxo8twRcWJbBD5Kow/Q2KhhDq5hxh2sKGDXn3uLc1tdtz4WUg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-7rw3nlubTjNAVRH2LwphCxHy1b/N2/TerXocQ6XRn4Q+buaY1Z7P/hbdALy1i1ex2yfOU2Xcij7ib7ZLi/lKfw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-1sel0t9MRjI/tdT89M8Dd6gPfANeeFP24Xa46R11WeHNwhjsXXZh+xUk50uWCRTSGcaCy3ugm3AMK/lmHYQJkg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-o2jH5AMfor4EKF2HII1LBnMQxoWu7+usPifTEY8Zk6e9OiSi4EJkAXf9v3ANlX7TI2V/cUEV34OEW7r10GiVIA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.1.0.tgz",
+      "integrity": "sha512-s6YDtDR1UWrsqJPtaxf+JLYLceWVyn3l8OpQYElHkDhf3Qfz9R6Ba3S0OgznTBv38L5/TIHysQ9Q4yO73Z0csg==",
       "cpu": [
         "wasm32"
       ],
@@ -1539,16 +1601,52 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-tools-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.1.0.tgz",
+      "integrity": "sha512-x+NuxbG84VxU68tU8w7Rf5lSyq0l584M6dVlke5DTweHYFZoMyeqkpbwEq+qsyAX6ivfipK8xRsmFwamb5uDnA==",
       "cpu": [
         "arm64"
       ],
@@ -1559,13 +1657,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-ia32-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.0.1.tgz",
-      "integrity": "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.1.0.tgz",
+      "integrity": "sha512-mdD96QDEp70SX67rXFTY6c725nVYeqEEjyDqzzbNh6u1APj7CI7IMNpMmvE75XbCRl4C2MHZVU4U6AWdAzvyQQ==",
       "cpu": [
         "ia32"
       ],
@@ -1576,13 +1674,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-bVVjuvhlyVX++3eJXfDR63cXdw1ay5QYac6iq0MKQw8wZARInTM+bXCtByDT4fzVFI3+7ZthYb/ERWRdBNIqgQ==",
       "cpu": [
         "x64"
       ],
@@ -1593,7 +1691,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1636,7 +1734,7 @@
     },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "dev": true,
       "license": "MIT",
@@ -1645,17 +1743,17 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.8.tgz",
+      "integrity": "sha512-L7y8eYc+AwxGr2PWI4WFt1VG4TiJ66c26BD16mXpYIlXxG0SMigM1+m4aTSlYyBr5BlQsGAlz8uDCoZN4SEMcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
+        "@octokit/graphql": "^9.0.5",
+        "@octokit/request": "^10.0.16",
+        "@octokit/request-error": "^7.1.2",
+        "@octokit/types": "^18.0.0",
         "before-after-hook": "^4.0.0",
         "universal-user-agent": "^7.0.0"
       },
@@ -1664,13 +1762,13 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.5.tgz",
+      "integrity": "sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0",
+        "@octokit/types": "^18.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -1678,14 +1776,14 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.5.tgz",
+      "integrity": "sha512-bt/hm03LeU6Vy7FwTrkkC9p3XGT/lBwClglMqxBSe5/q0E5CdJTXeAqEI0vlw89/LF/G6tryTIH8HirZ3prMVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
+        "@octokit/request": "^10.0.16",
+        "@octokit/types": "^18.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -1693,15 +1791,15 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "14.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "dev": true,
       "license": "MIT",
@@ -1715,9 +1813,26 @@
         "@octokit/core": ">=6"
       }
     },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@octokit/plugin-request-log": {
       "version": "6.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
       "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
       "dev": true,
       "license": "MIT",
@@ -1730,7 +1845,7 @@
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "17.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "dev": true,
       "license": "MIT",
@@ -1744,18 +1859,35 @@
         "@octokit/core": ">=6"
       }
     },
-    "node_modules/@octokit/request": {
-      "version": "10.0.8",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/request/-/request-10.0.8.tgz",
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
-        "json-with-bigint": "^3.5.3",
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.16.tgz",
+      "integrity": "sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.5",
+        "@octokit/request-error": "^7.1.2",
+        "@octokit/types": "^18.0.0",
+        "content-type": "^3.0.0",
+        "json-with-bigint": "^3.5.12",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -1763,13 +1895,13 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0"
+        "@octokit/types": "^18.0.0"
       },
       "engines": {
         "node": ">= 20"
@@ -1777,7 +1909,7 @@
     },
     "node_modules/@octokit/rest": {
       "version": "22.0.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/rest/-/rest-22.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
       "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
       "dev": true,
       "license": "MIT",
@@ -1792,13 +1924,13 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
+        "@octokit/openapi-types": "^29.0.1"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1868,15 +2000,15 @@
       "optional": true
     },
     "node_modules/@toon-format/toon": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.1.0.tgz",
-      "integrity": "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.1.tgz",
+      "integrity": "sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1885,19 +2017,19 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
-      "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1926,19 +2058,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2080,7 +2203,7 @@
     },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
@@ -2295,9 +2418,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2348,7 +2471,7 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/cli-width/-/cli-width-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
       "license": "ISC",
@@ -2358,7 +2481,7 @@
     },
     "node_modules/clipanion": {
       "version": "4.0.0-rc.4",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
       "integrity": "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==",
       "dev": true,
       "license": "MIT",
@@ -2431,9 +2554,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2444,12 +2567,17 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-3.0.0.tgz",
+      "integrity": "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie": {
@@ -2500,9 +2628,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2676,21 +2804,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/emnapi": {
-      "version": "1.9.2",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/emnapi/-/emnapi-1.9.2.tgz",
-      "integrity": "sha512-OdUoQe/8so7FvubnE/DNV9sNNSFwDYQiK4ZCAz4agMnD1s6faLuDn2gzxfJrmMoKfxZhhsckqGNwqPnS5K140A==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "node-addon-api": ">= 6.1.0"
-      },
-      "peerDependenciesMeta": {
-        "node-addon-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2748,14 +2861,16 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
-        "benchmarks"
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/escalade": {
@@ -3019,9 +3134,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -3037,27 +3152,19 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/express/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/fast-copy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.1.0.tgz",
+      "integrity": "sha512-IuCOCDFM1F/s4LtG7Bjr3yUUwPHybyhqN74xk2cMYoP51vVeErMy8+6HGFchi/+45lW8uzhs6lBeEqks2GWt6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3100,14 +3207,14 @@
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
       "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
       "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "dev": true,
       "license": "MIT",
@@ -3116,9 +3223,9 @@
       }
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3126,9 +3233,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3479,9 +3586,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3584,9 +3691,9 @@
       "optional": true
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3700,9 +3807,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3744,9 +3851,9 @@
       "license": "MIT"
     },
     "node_modules/json-with-bigint": {
-      "version": "3.5.8",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3821,12 +3928,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -3917,7 +4028,7 @@
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/mute-stream/-/mute-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
       "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true,
       "license": "ISC",
@@ -3946,10 +4057,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3960,9 +4100,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -3981,16 +4121,16 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
-      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
         "semver": "^7.5.3",
         "simple-update-notifier": "^2.0.0",
@@ -4009,6 +4149,29 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
+    "node_modules/nodemon/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4017,6 +4180,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -4055,15 +4234,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -4401,6 +4583,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4450,9 +4633,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -4494,9 +4677,9 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4515,9 +4698,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -4558,12 +4741,16 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -4775,9 +4962,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -4935,7 +5122,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
@@ -5122,9 +5309,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5308,7 +5495,7 @@
     },
     "node_modules/typanion": {
       "version": "3.14.0",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/typanion/-/typanion-3.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
       "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
       "dev": true,
       "license": "MIT",
@@ -5373,6 +5560,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -5381,15 +5582,15 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
-      "resolved": "https://npm.devsnc.com/repository/npm-all/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
@@ -5490,9 +5691,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
The committed lockfile carried 100 `resolved` URLs pointing at npm.devsnc.com (a private corporate npm mirror), written by an npm install run on that network. Anyone outside it got 403s from `npm install`/`npm ci` on a fresh clone, and the Docker build (COPY package-lock.json + npm ci) failed the same way. The published npm package was unaffected (lockfiles don't ship in packages) — only from-source installs broke.

Fully regenerated off the public registry: every resolved URL is now registry.npmjs.org (418 entries, zero private-mirror references). Verified with the full test suite (1278/1278) and a clean-room `npm ci --ignore-scripts` in a temp dir (298 packages, exit 0).

Adds a CI guard that fails if any non-public registry URL ever appears in the lockfile again — this recurs silently whenever someone on the corporate network runs `npm install` and commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a CI validation check to prevent package lockfiles from referencing unapproved package sources.
  * Workflow failures now provide guidance for correcting invalid package URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->