### PR TITLE
fix(ci): make npm audit resilient to registry advisory-endpoint outages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,32 @@ jobs:
         run: npx eslint src index.js --max-warnings 0
         timeout-minutes: 3
 
+      # npm audit needs the registry's advisory endpoint, which flaps during
+      # npm incidents: the POST hangs with no response (observed 2026-09-03,
+      # status page already claiming "operational") and the old bare step
+      # timed out, failing unrelated PRs. Policy: real vulnerability findings
+      # FAIL immediately; a hung/unreachable advisory service retries 3x and
+      # then warns-and-passes — npm's availability must not block merges, and
+      # the audit re-runs on every subsequent push anyway.
       - name: Audit (no high/critical)
-        run: npm audit --audit-level=high
-        timeout-minutes: 3
+        run: |
+          for attempt in 1 2 3; do
+            set +e
+            out=$(timeout 75 npm audit --audit-level=high 2>&1); code=$?
+            set -e
+            echo "$out" | tail -15
+            if [ "$code" -eq 0 ]; then exit 0; fi
+            if [ "$code" -eq 124 ]; then
+              echo "::warning::npm audit attempt $attempt timed out — registry advisory endpoint unresponsive"
+              continue
+            fi
+            # Non-zero, non-timeout: real vulnerabilities (or a real npm
+            # error) — fail loudly.
+            exit "$code"
+          done
+          echo "::warning::npm audit SKIPPED after 3 timeouts (npm registry incident). This is not a clean audit pass — re-run this job once npm recovers."
+          exit 0
+        timeout-minutes: 5
 
       - name: Test
         run: |


### PR DESCRIPTION
## Problem

npm's bulk advisory endpoint (`/-/npm/v1/security/advisories/bulk`) flaps during registry incidents — the POST hangs with no response. Observed live on 2026-09-03, including while npm's status page already claimed "All Systems Operational". The bare `npm audit` step then hit its 3-minute cap and failed CI on unrelated changes: #102 was red on first run, green on rerun, and main went red again post-merge — all on an identical diff.

## Fix

The audit step now encodes an explicit policy:

- **Real vulnerability findings (or real npm errors) fail immediately** — no change to the security bar.
- **A hung advisory endpoint** (timeout, exit 124) retries up to 3× at 75s each, then emits a loud `::warning::` and passes — npm's availability must not block merges, and the audit re-runs on every push anyway.

Exit-code semantics verified for both paths before committing (simulated exit-124 → retries then pass-with-warning; simulated exit-1 → immediate failure).

## Notes

- This also explains the current red X on main (post-merge run of #102) — no action needed there beyond a rerun once npm stabilizes, or simply landing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Dependency security checks now retry automatically when they time out.
  * Checks fail immediately when vulnerabilities or other non-timeout errors are detected.
  * Repeated timeouts produce a warning instead of failing the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->