### PR TITLE
ci: auto code review on PRs via OpenCodeReview (free tier)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -4,18 +4,16 @@
 # plus on-demand re-review via `/open-code-review` comments.
 # Hosted 100% on GitHub Actions free minutes (public repo = free).
 #
-# Cost design (mirrors local Lynkr tiers in ~/.env):
-#   Lynkr local:  TIER_SIMPLE/MEDIUM/COMPLEX -> openai:muse-spark ($0),
-#                 TIER_REASONING -> azure-openai:gpt-5.6-sol (paid)
-#   CI here:      OpenRouter `:free` model ($0) + `effort: low` so reviews
-#                 stay inside the SIMPLE-tier budget. No server to host.
+# Cost design: Inception Mercury 2.5 diffusion LLM (OpenAI-compatible).
+# Fast (~1000 tok/s) and cheap ($0.20/1M in, $0.75/1M out) with 260K context.
+# `effort: low` + `reasoning_effort: low` keep reviews quick and cheap.
 # To change the model later, edit the repo Variable (no code change):
 #   Settings -> Secrets and variables -> Actions -> Variables -> OCR_LLM_MODEL
 #
 # Required secrets/vars (Settings -> Secrets and variables -> Actions):
-#   secret    OCR_LLM_URL            e.g. https://openrouter.ai/api/v1/chat/completions
-#   secret    OCR_LLM_AUTH_TOKEN     OpenRouter API key (free models cost $0)
-#   variable  OCR_LLM_MODEL          e.g. nvidia/nemotron-3-nano-30b-a3b:free
+#   secret    OCR_LLM_URL            e.g. https://api.inceptionlabs.ai/v1/chat/completions
+#   secret    OCR_LLM_AUTH_TOKEN     Inception API key
+#   variable  OCR_LLM_MODEL          e.g. mercury-2.5
 #   variable  OCR_LLM_USE_ANTHROPIC  'false' for OpenAI-compatible endpoints
 #
 # Source: https://github.com/alibaba/open-code-review/tree/main/examples/github_actions
@@ -102,9 +100,13 @@ jobs:
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
           llm_model: ${{ vars.OCR_LLM_MODEL }}
           llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
-          # Keep reviews inside the free-tier budget: low effort, sticky
-          # summary so re-pushes update one comment instead of spamming.
+          # Keep reviews fast and cheap on the diffusion model: low effort,
+          # low reasoning, sticky summary so re-pushes update one comment.
           effort: low
+          llm_reasoning_effort: 'low'
+          # Override the action's default thinking-disable payload, which
+          # Mercury doesn't need; send a clean body instead.
+          llm_extra_body: '{}'
           sticky_summary: 'true'
           base_ref: ${{ steps.pr-context.outputs.base_ref }}
           head_sha: ${{ steps.pr-context.outputs.head_sha }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Get PR context
         id: pr-context
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const prNumber = context.issue.number;
@@ -94,8 +94,9 @@ jobs:
             core.setOutput('head_sha', pullRequest.head.sha);
 
       - name: Run OpenCodeReview
-        uses: alibaba/open-code-review@main
+        uses: alibaba/open-code-review@494bf1c8d7a19196ab166960a06fef38d69a1d16 # v1.12.0 (pinned SHA)
         with:
+          ocr_version: '1.12.0'
           llm_url: ${{ secrets.OCR_LLM_URL }}
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
           llm_model: ${{ vars.OCR_LLM_MODEL }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,110 @@
+# OpenCodeReview - GitHub Actions PR Auto-Review (free tier + Lynkr-tier-aligned)
+#
+# Triggers a code review every time a PR is opened/updated on this repo,
+# plus on-demand re-review via `/open-code-review` comments.
+# Hosted 100% on GitHub Actions free minutes (public repo = free).
+#
+# Cost design (mirrors local Lynkr tiers in ~/.env):
+#   Lynkr local:  TIER_SIMPLE/MEDIUM/COMPLEX -> openai:muse-spark ($0),
+#                 TIER_REASONING -> azure-openai:gpt-5.6-sol (paid)
+#   CI here:      OpenRouter `:free` model ($0) + `effort: low` so reviews
+#                 stay inside the SIMPLE-tier budget. No server to host.
+# To change the model later, edit the repo Variable (no code change):
+#   Settings -> Secrets and variables -> Actions -> Variables -> OCR_LLM_MODEL
+#
+# Required secrets/vars (Settings -> Secrets and variables -> Actions):
+#   secret    OCR_LLM_URL            e.g. https://openrouter.ai/api/v1/chat/completions
+#   secret    OCR_LLM_AUTH_TOKEN     OpenRouter API key (free models cost $0)
+#   variable  OCR_LLM_MODEL          e.g. nvidia/nemotron-3-nano-30b-a3b:free
+#   variable  OCR_LLM_USE_ANTHROPIC  'false' for OpenAI-compatible endpoints
+#
+# Source: https://github.com/alibaba/open-code-review/tree/main/examples/github_actions
+
+name: OpenCodeReview PR Review
+
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event_name == 'pull_request_target'
+        || (
+          github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && (
+            github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'COLLABORATOR'
+          )
+          && (
+            startsWith(github.event.comment.body, '/open-code-review')
+            || startsWith(github.event.comment.body, '@open-code-review')
+          )
+        )
+      )
+      && format('ocr-{0}', github.event.pull_request.number || github.event.issue.number)
+      || format('noop-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+on:
+  # pull_request_target (not pull_request) so secrets are available for fork
+  # PRs. Safe: the action only reads the diff, never executes PR code.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'pull_request_target'
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && (
+          github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+        && (
+          startsWith(github.event.comment.body, '/open-code-review')
+          || startsWith(github.event.comment.body, '@open-code-review')
+        )
+      )
+    steps:
+      - name: Get PR context
+        id: pr-context
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@main
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: ${{ vars.OCR_LLM_MODEL }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          # Keep reviews inside the free-tier budget: low effort, sticky
+          # summary so re-pushes update one comment instead of spamming.
+          effort: low
+          sticky_summary: 'true'
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}


### PR DESCRIPTION
Adds .github/workflows/ocr-review.yml: every PR (opened/synchronize/reopened) triggers an Alibaba open-code-review run on GitHub-hosted runners (free for this public repo), plus on-demand re-review via `/open-code-review` comments.

Cost design mirrors local Lynkr tiers (SIMPLE/MEDIUM/COMPLEX -> free models):
- LLM = OpenRouter :free model (repo Variable OCR_LLM_MODEL, currently nvidia/nemotron-3-nano-30b-a3b:free, $0)
- effort: low + sticky summary to stay in budget and avoid comment spam
- Secrets OCR_LLM_URL / OCR_LLM_AUTH_TOKEN already set; model switchable via Variables with no code change.

Note: pull_request_target runs the workflow from base, so this setup PR itself won't be reviewed until after merge - open any test PR after merging to see it fire.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This revision hardens the OpenCodeReview workflow by replacing mutable third-party action references with full commit SHAs and selecting an immutable OpenCodeReview CLI release.
- Pins `actions/github-script` to the commit annotated as v7.0.1.
- Pins `alibaba/open-code-review` to the commit annotated as v1.12.0.
- Configures `ocr_version` as `1.12.0`.
- Leaves the previously reported unsupported `llm_reasoning_effort` setting unchanged.

<h3>Confidence Score: 5/5</h3>

The latest changes appear safe to merge, although the existing non-blocking warning that `llm_reasoning_effort` is ignored remains outstanding.

The mutable privileged action references identified previously are now pinned and that thread was resolved. The unresolved previous finding remains valid because `llm_reasoning_effort` is still supplied even though it is not a declared OpenCodeReview action input, so the intended low-reasoning cost and latency control is not applied.

**Files Needing Attention:** .github/workflows/ocr-review.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ocr-review.yml | Pins both workflow actions and the OpenCodeReview CLI version; the unresolved low-reasoning input from the previous review remains unchanged. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: pin ocr action and CLI to immutable ..."](https://github.com/fast-editor/lynkr/commit/ac37207ef91cf2521baf4cb0a7c73cdafd718773) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63570895)</sub>

<!-- /greptile_comment -->